### PR TITLE
Example downloads & reader/writer updates

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,11 +9,12 @@ import vtki
 from vtki import examples
 from vtki.plotting import running_xserver
 
+TEST_DOWNLOADS = False
 try:
-    os.environ['TEST_DOWNLOADS']
-    TEST_DOWNLOADS = True
+    if os.environ['TEST_DOWNLOADS'] == 'True':
+        TEST_DOWNLOADS = True
 except KeyError:
-    TEST_DOWNLOADS = False
+    pass
 
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,11 @@ import vtki
 from vtki import examples
 from vtki.plotting import running_xserver
 
-TEST_DOWNLOADS = False
+try:
+    os.environ['TEST_DOWNLOADS']
+    TEST_DOWNLOADS = True
+except KeyError:
+    TEST_DOWNLOADS = False
 
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ from subprocess import PIPE, Popen
 
 import numpy as np
 import pytest
+import vtk
 
 import vtki
 from vtki import examples
@@ -114,3 +115,47 @@ def test_load_channels():
     """ Loads geostat training image """
     mesh = examples.load_channels()
     assert mesh.n_points
+
+def test_download_masonry_texture():
+    data = examples.download_masonry_texture()
+    assert isinstance(data, vtk.vtkTexture)
+
+def test_download_usa_texture():
+    data = examples.download_usa_texture()
+    assert isinstance(data, vtk.vtkTexture)
+
+def test_download_usa():
+    data = examples.download_usa()
+    assert np.any(data.points)
+
+def test_download_st_helens():
+    data = examples.download_st_helens()
+    assert data.n_points
+
+def test_download_bunny():
+    data = examples.download_bunny()
+    assert data.n_points
+
+def test_download_cow():
+    data = examples.download_cow()
+    assert data.n_points
+
+def test_download_faults():
+    data = examples.download_faults()
+    assert data.n_points
+
+def test_download_tensors():
+    data = examples.download_tensors()
+    assert data.n_points
+
+def test_download_head():
+    data = examples.download_head()
+    assert data.n_points
+
+def test_download_bolt_nut():
+    data = examples.download_bolt_nut()
+    assert isinstance(data, vtki.MultiBlock)
+
+def test_download_clown():
+    data = examples.download_clown()
+    assert data.n_points

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,6 +9,8 @@ import vtki
 from vtki import examples
 from vtki.plotting import running_xserver
 
+TEST_DOWNLOADS = False
+
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")
 def test_docexample_advancedplottingwithnumpy():
@@ -116,46 +118,50 @@ def test_load_channels():
     mesh = examples.load_channels()
     assert mesh.n_points
 
-def test_download_masonry_texture():
-    data = examples.download_masonry_texture()
-    assert isinstance(data, vtk.vtkTexture)
+if TEST_DOWNLOADS:
 
-def test_download_usa_texture():
-    data = examples.download_usa_texture()
-    assert isinstance(data, vtk.vtkTexture)
+    def test_download_masonry_texture():
+        data = examples.download_masonry_texture()
+        assert isinstance(data, vtk.vtkTexture)
 
-def test_download_usa():
-    data = examples.download_usa()
-    assert np.any(data.points)
+    def test_download_usa_texture():
+        data = examples.download_usa_texture()
+        assert isinstance(data, vtk.vtkTexture)
 
-def test_download_st_helens():
-    data = examples.download_st_helens()
-    assert data.n_points
+    def test_download_usa():
+        data = examples.download_usa()
+        assert np.any(data.points)
 
-def test_download_bunny():
-    data = examples.download_bunny()
-    assert data.n_points
+    def test_download_st_helens():
+        data = examples.download_st_helens()
+        assert data.n_points
 
-def test_download_cow():
-    data = examples.download_cow()
-    assert data.n_points
+    def test_download_bunny():
+        data = examples.download_bunny()
+        assert data.n_points
 
-def test_download_faults():
-    data = examples.download_faults()
-    assert data.n_points
+    def test_download_cow():
+        data = examples.download_cow()
+        assert data.n_points
 
-def test_download_tensors():
-    data = examples.download_tensors()
-    assert data.n_points
+    def test_download_faults():
+        data = examples.download_faults()
+        assert data.n_points
 
-def test_download_head():
-    data = examples.download_head()
-    assert data.n_points
+    def test_download_tensors():
+        data = examples.download_tensors()
+        assert data.n_points
 
-def test_download_bolt_nut():
-    data = examples.download_bolt_nut()
-    assert isinstance(data, vtki.MultiBlock)
+    def test_download_head():
+        data = examples.download_head()
+        assert data.n_points
 
-def test_download_clown():
-    data = examples.download_clown()
-    assert data.n_points
+    def test_download_bolt_nut():
+        data = examples.download_bolt_nut()
+        assert isinstance(data, vtki.MultiBlock)
+
+    def test_download_clown():
+        data = examples.download_clown()
+        assert data.n_points
+
+# End of download tests

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -221,7 +221,7 @@ def test_invalid_curvature():
 
 
 @pytest.mark.parametrize('binary', [True, False])
-@pytest.mark.parametrize('extension', ['stl', 'vtk', 'ply'])
+@pytest.mark.parametrize('extension', ['stl', 'vtk', 'ply', 'vtp'])
 def test_save(extension, binary, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
     sphere.save(filename, binary)

--- a/vtki/examples/__init__.py
+++ b/vtki/examples/__init__.py
@@ -1,1 +1,2 @@
 from vtki.examples.examples import *
+from vtki.examples.downloads import *

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -1,5 +1,6 @@
 """Functions to download sampe datasets from the VTK data repository
 """
+import shutil
 import os
 import sys
 
@@ -29,7 +30,7 @@ def _retrieve_file(url, filename):
         saved_file, resp = urlretrieve(url)
         # rename saved file:
         new_name = saved_file.replace(os.path.basename(saved_file), filename)
-        os.rename(saved_file, new_name)
+        shutil.move(saved_file, new_name)
         return new_name, resp
     return urlretrieve(url, filename)
 

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -6,6 +6,13 @@ import sys
 
 import vtki
 
+
+DOWNLOAD_TEMP_FOLDER = True
+"""
+A flag to save downloads in a temporary directory or the current working
+directory.
+"""
+
 # Helpers:
 
 def _get_vtk_file_url(filename):
@@ -17,6 +24,12 @@ def _retrieve_file(url, filename):
         urlretrieve = urllib.urlretrieve
     else:
         urlretrieve = urllib.request.urlretrieve
+    if DOWNLOAD_TEMP_FOLDER:
+        saved_file, resp = urlretrieve(url)
+        # rename saved file:
+        new_name = saved_file.replace(os.path.basename(saved_file), filename)
+        os.rename(saved_file, new_name)
+        return new_name, resp
     return urlretrieve(url, filename)
 
 def _download_file(filename):
@@ -24,10 +37,10 @@ def _download_file(filename):
     return _retrieve_file(url, filename)
 
 def _download_and_read(filename, texture=False):
-    _download_file(filename)
+    saved_file, _ = _download_file(filename)
     if texture:
-        return vtki.read_texture(filename)
-    return vtki.read(filename)
+        return vtki.read_texture(saved_file)
+    return vtki.read(saved_file)
 
 
 # Textures:
@@ -46,6 +59,8 @@ def download_usa():
 
 def download_st_helens():
     return _download_and_read('SainteHelens.dem')
+
+download_st_helens()
 
 def download_bunny():
     return _download_and_read('bunny.ply')

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -1,6 +1,5 @@
 """Functions to download sampe datasets from the VTK data repository
 """
-import urllib
 import os
 import sys
 
@@ -20,9 +19,11 @@ def _get_vtk_file_url(filename):
 
 def _retrieve_file(url, filename):
     # grab the correct url retriever
-    if sys.version_info < (3,) or os.name == 'nt':
+    if sys.version_info < (3,):
+        import urllib
         urlretrieve = urllib.urlretrieve
     else:
+        import urllib.request
         urlretrieve = urllib.request.urlretrieve
     if DOWNLOAD_TEMP_FOLDER:
         saved_file, resp = urlretrieve(url)

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -6,18 +6,17 @@ import sys
 
 import vtki
 
-# grab the correct url retriever
-if sys.version_info < (3,):
-    urlretrieve = urllib.urlretrieve
-else:
-    urlretrieve = urllib.request.urlretrieve
-
 # Helpers:
 
 def _get_vtk_file_url(filename):
     return 'https://github.com/open-cv/VTKData/raw/master/Data/{}'.format(filename)
 
 def _retrieve_file(url, filename):
+    # grab the correct url retriever
+    if sys.version_info < (3,) or os.name == 'nt':
+        urlretrieve = urllib.urlretrieve
+    else:
+        urlretrieve = urllib.request.urlretrieve
     return urlretrieve(url, filename)
 
 def _download_file(filename):

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -1,0 +1,74 @@
+"""Functions to download sampe datasets from the VTK data repository
+"""
+import urllib
+import os
+import sys
+
+import vtki
+
+# grab the correct url retriever
+if sys.version_info < (3,):
+    urlretrieve = urllib.urlretrieve
+else:
+    urlretrieve = urllib.request.urlretrieve
+
+# Helpers:
+
+def _get_vtk_file_url(filename):
+    return 'https://github.com/open-cv/VTKData/raw/master/Data/{}'.format(filename)
+
+def _retrieve_file(url, filename):
+    return urlretrieve(url, filename)
+
+def _download_file(filename):
+    url = _get_vtk_file_url(filename)
+    return _retrieve_file(url, filename)
+
+def _download_and_read(filename, texture=False):
+    _download_file(filename)
+    if texture:
+        return vtki.read_texture(filename)
+    return vtki.read(filename)
+
+
+# Textures:
+
+def download_masonry_texture():
+    return _download_and_read('masonry.bmp', texture=True)
+
+def download_usa_texture():
+    return _download_and_read('usa_image.jpg', texture=True)
+
+
+# Examples:
+
+def download_usa():
+    return _download_and_read('usa.vtk')
+
+def download_st_helens():
+    return _download_and_read('SainteHelens.dem')
+
+def download_bunny():
+    return _download_and_read('bunny.ply')
+
+def download_cow():
+    return _download_and_read('cow.vtp')
+
+def download_faults():
+    return _download_and_read('faults.vtk')
+
+def download_tensors():
+    return _download_and_read('tensors.vtk')
+
+def download_head():
+    _download_file('HeadMRVolume.raw')
+    return _download_and_read('HeadMRVolume.mhd')
+
+def download_bolt_nut():
+    blocks = vtki.MultiBlock()
+    blocks['bolt'] =  _download_and_read('bolt.slc')
+    blocks['nut'] = _download_and_read('nut.slc')
+    return blocks
+
+def download_clown():
+    return _download_and_read('clown.facet')

--- a/vtki/grid.py
+++ b/vtki/grid.py
@@ -204,18 +204,22 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkRectilinearGridWriter()
-            legacy = True
+            if binary:
+                writer.SetFileTypeToBinary()
+            else:
+                writer.SetFileTypeToASCII()
         elif '.vtr' in filename:
             writer = vtk.vtkXMLRectilinearGridWriter()
-            legacy = False
+            if binary:
+                writer.SetDataModeToBinary()
+            else:
+                writer.SetDataModeToAscii()
         else:
             raise Exception('Extension should be either ".vtr" (xml) or' +
                             '".vtk" (legacy)')
         # Write
         writer.SetFileName(filename)
         writer.SetInputData(self)
-        if binary and legacy:
-            writer.SetFileTypeToBinary()
         writer.Write()
 
     @property
@@ -469,18 +473,22 @@ class UniformGrid(vtkImageData, Grid):
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkDataSetWriter()
-            legacy = True
+            if binary:
+                writer.SetFileTypeToBinary()
+            else:
+                writer.SetFileTypeToASCII()
         elif '.vti' in filename:
             writer = vtk.vtkXMLImageDataWriter()
-            legacy = False
+            if binary:
+                writer.SetDataModeToBinary()
+            else:
+                writer.SetDataModeToAscii()
         else:
             raise Exception('Extension should be either ".vti" (xml) or' +
                             '".vtk" (legacy)')
         # Write
         writer.SetFileName(filename)
         writer.SetInputData(self)
-        if binary and legacy:
-            writer.SetFileTypeToBinary()
         writer.Write()
 
     @property

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -865,7 +865,7 @@ class BasePlotter(object):
             self._labels.append([single_triangle(), label, rgb_color])
 
         # lighting display style
-        if lighting is False:
+        if not lighting:
             prop.LightingOff()
 
         # set line thickness

--- a/vtki/pointset.py
+++ b/vtki/pointset.py
@@ -130,10 +130,12 @@ class PolyData(vtkPolyData, vtki.Common):
             reader = vtk.vtkSTLReader()
         elif ext == '.vtk':
             reader = vtk.vtkPolyDataReader()
+        elif ext == '.vtp':
+            reader = vtk.vtkXMLPolyDataReader()
         elif ext == '.obj':
             reader = vtk.vtkOBJReader()
         else:
-            raise TypeError('Filetype must be either "ply", "stl", or "vtk"')
+            raise TypeError('Filetype must be either "ply", "stl", "vtk", "vtp", or "obj".')
 
         # Load file
         reader.SetFileName(filename)
@@ -493,10 +495,18 @@ class PolyData(vtkPolyData, vtki.Common):
         file size.
         """
         filename = os.path.abspath(os.path.expanduser(filename))
+        file_mode = True
         # Check filetype
         ftype = filename[-3:]
         if ftype == 'ply':
             writer = vtk.vtkPLYWriter()
+        elif ftype == 'vtp':
+            writer = vtk.vtkXMLPolyDataWriter()
+            file_mode = False
+            if binary:
+                writer.SetDataModeToBinary()
+            else:
+                writer.SetDataModeToAscii()
         elif ftype == 'stl':
             writer = vtk.vtkSTLWriter()
         elif ftype == 'vtk':
@@ -506,9 +516,9 @@ class PolyData(vtkPolyData, vtki.Common):
 
         writer.SetFileName(filename)
         writer.SetInputData(self)
-        if binary:
+        if binary and file_mode:
             writer.SetFileTypeToBinary()
-        else:
+        elif file_mode:
             writer.SetFileTypeToASCII()
         writer.Write()
 
@@ -1775,18 +1785,22 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid):
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkUnstructuredGridWriter()
-            legacy = True
+            if binary:
+                writer.SetFileTypeToBinary()
+            else:
+                writer.SetFileTypeToASCII()
         elif '.vtu' in filename:
             writer = vtk.vtkXMLUnstructuredGridWriter()
-            legacy = False
+            if binary:
+                writer.SetDataModeToBinary()
+            else:
+                writer.SetDataModeToAscii()
         else:
             raise Exception('Extension should be either ".vtu" or ".vtk"')
 
         writer.SetFileName(filename)
         writer.SetInputData(self)
-        if binary and legacy:
-            writer.SetFileTypeToBinary()
-        writer.Write()
+        return writer.Write()
 
     @property
     def cells(self):
@@ -2176,18 +2190,22 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkStructuredGridWriter()
-            legacy = True
+            if binary:
+                writer.SetFileTypeToBinary()
+            else:
+                writer.SetFileTypeToASCII()
         elif '.vts' in filename:
             writer = vtk.vtkXMLStructuredGridWriter()
-            legacy = False
+            if binary:
+                writer.SetDataModeToBinary()
+            else:
+                writer.SetDataModeToAscii()
         else:
             raise Exception('Extension should be either ".vts" (xml) or' +
                             '".vtk" (legacy)')
         # Write
         writer.SetFileName(filename)
         writer.SetInputData(self)
-        if binary and legacy:
-            writer.SetFileTypeToBinary()
         writer.Write()
 
     @property

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -16,6 +16,7 @@ READERS = {
     '.ply': vtk.vtkPLYReader,
     '.obj': vtk.vtkOBJReader,
     '.stl': vtk.vtkSTLReader,
+    '.vtp': vtk.vtkXMLPolyDataReader,
     '.vts': vtk.vtkXMLStructuredGridReader,
     '.vtm': vtk.vtkXMLMultiBlockDataReader,
     '.vtmb': vtk.vtkXMLMultiBlockDataReader,

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -22,45 +22,32 @@ READERS = {
     # Image formats:
     '.bmp': vtk.vtkBMPReader,
     '.dem': vtk.vtkDEMReader,
-    '.dcm': vtk.vtkDICOMImageReader,
+    '.dcm': vtk.vtkDICOMImageReader, # TODO: not tested
     '.jpeg': vtk.vtkJPEGReader,
     '.jpg': vtk.vtkJPEGReader,
+    '.mhd': vtk.vtkMetaImageReader,
     '.png': vtk.vtkPNGReader,
-    '.pnm': vtk.vtkPNMReader,
+    '.pnm': vtk.vtkPNMReader, # TODO: not tested
     '.slc': vtk.vtkSLCReader,
     '.tiff': vtk.vtkTIFFReader,
     '.tif': vtk.vtkTIFFReader,
-    # ExodusII files:
-    #.g, .e, .ex2, .ex2v2, .exo, .gen, .exoII, .exii, .0, .00, .000
-    '.g': vtk.vtkExodusIIReader,
-    '.e': vtk.vtkExodusIIReader,
-    '.ex2': vtk.vtkExodusIIReader,
-    '.ex2v2': vtk.vtkExodusIIReader,
-    '.exo': vtk.vtkExodusIIReader,
-    '.gen': vtk.vtkExodusIIReader,
-    '.exoii': vtk.vtkExodusIIReader,
-    '.exii': vtk.vtkExodusIIReader,
-    '.0': vtk.vtkExodusIIReader,
-    '.00': vtk.vtkExodusIIReader,
-    '.000': vtk.vtkExodusIIReader,
     # Other formats:
-    '.byu': vtk.vtkBYUReader,
-    '.chemml': vtk.vtkCMLMoleculeReader,
-    '.cml': vtk.vtkCMLMoleculeReader,
+    '.byu': vtk.vtkBYUReader, # TODO: not tested
+    '.chemml': vtk.vtkCMLMoleculeReader, # TODO: not tested
+    # '.cml': vtk.vtkCMLMoleculeReader, # vtkMolecule is not supported by vtki
     # TODO: '.csv': vtk.vtkCSVReader, # vtkTables are currently not supported
     '.facet': vtk.vtkFacetReader,
-    '.cas': vtk.vtkFLUENTReader,
-    '.dat': vtk.vtkFLUENTReader,
-    '.cube': vtk.vtkGaussianCubeReader,
-    '.res': vtk.vtkMFIXReader,
+    '.cas': vtk.vtkFLUENTReader, # TODO: not tested
+    # '.dat': vtk.vtkFLUENTReader, # TODO: not working
+    # '.cube': vtk.vtkGaussianCubeReader, # Contains `atom_types` which are note supported?
+    '.res': vtk.vtkMFIXReader, # TODO: not tested
     '.foam': vtk.vtkOpenFOAMReader,
-    '.pdb': vtk.vtkPDBReader,
+    # '.pdb': vtk.vtkPDBReader, # Contains `atom_types` which are note supported?
     '.p3d': vtk.vtkPlot3DMetaReader,
     '.pts': vtk.vtkPTSReader,
-    '.particles': vtk.vtkParticleReader,
+    '.particles': vtk.vtkParticleReader, # TODO: not tested
     #TODO: '.pht': vtk.vtkPhasta??????,
     #TODO: '.vpc': vtk.vtkVPIC?????,
-    '.xyz': vtk.vtkXYZMolReader,
 }
 
 

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -23,7 +23,7 @@ READERS = {
     # Image formats:
     '.bmp': vtk.vtkBMPReader,
     '.dem': vtk.vtkDEMReader,
-    '.dcm': vtk.vtkDICOMImageReader, # TODO: not tested
+    #'.dcm': vtk.vtkDICOMImageReader, # TODO: not tested and not working
     '.jpeg': vtk.vtkJPEGReader,
     '.jpg': vtk.vtkJPEGReader,
     '.mhd': vtk.vtkMetaImageReader,
@@ -34,7 +34,7 @@ READERS = {
     '.tif': vtk.vtkTIFFReader,
     # Other formats:
     '.byu': vtk.vtkBYUReader, # TODO: not tested
-    '.chemml': vtk.vtkCMLMoleculeReader, # TODO: not tested
+    # '.chemml': vtk.vtkCMLMoleculeReader, # TODO: not tested
     # '.cml': vtk.vtkCMLMoleculeReader, # vtkMolecule is not supported by vtki
     # TODO: '.csv': vtk.vtkCSVReader, # vtkTables are currently not supported
     '.facet': vtk.vtkFacetReader,
@@ -46,7 +46,7 @@ READERS = {
     # '.pdb': vtk.vtkPDBReader, # Contains `atom_types` which are note supported?
     '.p3d': vtk.vtkPlot3DMetaReader,
     '.pts': vtk.vtkPTSReader,
-    '.particles': vtk.vtkParticleReader, # TODO: not tested
+    # '.particles': vtk.vtkParticleReader, # TODO: not tested
     #TODO: '.pht': vtk.vtkPhasta??????,
     #TODO: '.vpc': vtk.vtkVPIC?????,
 }


### PR DESCRIPTION
This adds the ability to download a few examples from the VTK examples repository.

It also cleans up some to the experimental universal readers code.

### Todo

- [ ] all readers need to be tested
- [x] example downloads need to be tested?
- [x] should examples download to temp folder or to working directory?
- [ ] a second dictionary of `attrs` and arguments needs to be created for readers that do not work out of the box
- [x] Fix issue with windows `urllib` bug

### Example

```py
import vtki
from vtki import examples

head = examples.download_head()

tool = vtki.OrthogonalSlicer(head)

vol = head.contour([15])
tool.plotter.add_mesh(vol, color='yellow', name='skin', opacity=0.5)

```

![foo](https://user-images.githubusercontent.com/22067021/53694019-c2297980-3d65-11e9-9c18-7f401f56c1c0.png)


### Note

Including tests for the downloads might not be a good idea... it slows down the testing suite significantly.