### PR TITLE
Add abstract class protections

### DIFF
--- a/vtki/common.py
+++ b/vtki/common.py
@@ -20,11 +20,16 @@ log.setLevel('CRITICAL')
 DEFAULT_VECTOR_KEY = '_vectors'
 
 
-class Common(DataSetFilters):
+class Common(DataSetFilters, object):
     """ Methods in common to grid and surface objects"""
 
     # Simply bind vtki.plotting.plot to the object
     plot = vtki.plot
+
+    def __new__(cls, *args, **kwargs):
+        if cls is Common:
+            raise TypeError("vtki.Common is an abstract class and may not be instantiated.")
+        return object.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         self.references = []

--- a/vtki/filters.py
+++ b/vtki/filters.py
@@ -64,6 +64,11 @@ def _generate_plane(normal, origin):
 class DataSetFilters(object):
     """A set of common filters that can be applied to any vtkDataSet"""
 
+    def __new__(cls, *args, **kwargs):
+        if cls is DataSetFilters:
+            raise TypeError("vtki.DataSetFilters is an abstract class and may not be instantiated.")
+        return object.__new__(cls, *args, **kwargs)
+
 
     def clip(dataset, normal='x', origin=None, invert=True):
         """

--- a/vtki/filters.py
+++ b/vtki/filters.py
@@ -67,7 +67,7 @@ class DataSetFilters(object):
     def __new__(cls, *args, **kwargs):
         if cls is DataSetFilters:
             raise TypeError("vtki.DataSetFilters is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
+        return object.__new__(cls)
 
 
     def clip(dataset, normal='x', origin=None, invert=True):

--- a/vtki/grid.py
+++ b/vtki/grid.py
@@ -18,6 +18,11 @@ log.setLevel('CRITICAL')
 class Grid(vtki.Common):
     """A class full of common methods for non-pointset grids """
 
+    def __new__(cls, *args, **kwargs):
+        if cls is Grid:
+            raise TypeError("vtki.Grid is an abstract class and may not be instantiated.")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self, *args, **kwargs):
         super(Grid, self).__init__()
 

--- a/vtki/ipy_tools.py
+++ b/vtki/ipy_tools.py
@@ -68,6 +68,11 @@ class InteractiveTool(object):
     the ``plotter`` argument.
     """
 
+    def __new__(cls, *args, **kwargs):
+        if cls is InteractiveTool:
+            raise TypeError("vtki.InteractiveTool is an abstract class and may not be instantiated.")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self, dataset, plotter=None, scalars=None, preference='cell',
                  show_bounds=False, reset_camera=True, outline=None,
                  display_params=None, default_params=None,

--- a/vtki/ipy_tools.py
+++ b/vtki/ipy_tools.py
@@ -71,7 +71,7 @@ class InteractiveTool(object):
     def __new__(cls, *args, **kwargs):
         if cls is InteractiveTool:
             raise TypeError("vtki.InteractiveTool is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
+        return object.__new__(cls)
 
     def __init__(self, dataset, plotter=None, scalars=None, preference='cell',
                  show_bounds=False, reset_camera=True, outline=None,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -293,6 +293,11 @@ class BasePlotter(object):
 
     """
 
+    def __new__(cls, *args, **kwargs):
+        if cls is BasePlotter:
+            raise TypeError("vtki.BasePlotter is an abstract class and may not be instantiated.")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self, shape=(1, 1), border=None, border_color='k',
                  border_width=1.0):
         """ Initialize base plotter """

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -293,6 +293,11 @@ class BasePlotter(object):
 
     """
 
+    def __new__(cls, *args, **kwargs):
+        if cls is BasePlotter:
+            raise TypeError("vtki.BasePlotter is an abstract class and may not be instantiated.")
+        return object.__new__(cls)
+
     def __init__(self, shape=(1, 1), border=None, border_color='k',
                  border_width=1.0):
         """ Initialize base plotter """

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -293,11 +293,6 @@ class BasePlotter(object):
 
     """
 
-    def __new__(cls, *args, **kwargs):
-        if cls is BasePlotter:
-            raise TypeError("vtki.BasePlotter is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
-
     def __init__(self, shape=(1, 1), border=None, border_color='k',
                  border_width=1.0):
         """ Initialize base plotter """

--- a/vtki/pointset.py
+++ b/vtki/pointset.py
@@ -1424,6 +1424,11 @@ class PolyData(vtkPolyData, vtki.Common):
 class PointGrid(vtki.Common):
     """ Class in common with structured and unstructured grids """
 
+    def __new__(cls, *args, **kwargs):
+        if cls is PointGrid:
+            raise TypeError("vtki.PointGrid is an abstract class and may not be instantiated.")
+        return object.__new__(cls, *args, **kwargs)
+
     def __init__(self, *args, **kwargs):
         super(PointGrid, self).__init__()
 


### PR DESCRIPTION
This adds checks to the abstract classes in `vtki` to prevent users from instantiating helper classes like `vtki.Common`. I think I did this correctly but @akaszynski, I'd appreciate your approval.

```py
>>> import vtki
>>> vtki.Common()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/bane/Documents/OpenGeoVis/Software/vtki/vtki/common.py", line 31, in __new__
    raise TypeError("vtki.Common is an abstract class and may not be instantiated.")
TypeError: vtki.Common is an abstract class and may not be instantiated.
```