### PR TITLE
Custom colormaps and opacity transfer functions

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -853,7 +853,9 @@ class BasePlotter(object):
                     from matplotlib.cm import get_cmap
                 except ImportError:
                     raise Exception('cmap requires matplotlib')
-                cmap = get_cmap(cmap)
+                if isinstance(cmap, str):
+                    cmap = get_cmap(cmap)
+                    # ELSE: assume cmap is callable
                 ctable = cmap(np.linspace(0, 1, n_colors))*255
                 ctable = ctable.astype(np.uint8)
                 if flip_scalars:


### PR DESCRIPTION
Adds the ability to use custom colormaps (#122) and the option for different opacity transfer functions (#125). Options include:

- `'linear'`: linearly vary (increase) opacity across the plotted scalar range from low to high
- `'linear_r'`: linearly vary (increase) opacity across the plotted scalar range from high to low
- `'geom'`: on a log scale, vary (increase) opacity across the plotted scalar range from low to high
- `'geom_r'`: on a log scale, vary (increase) opacity across the plotted scalar range from high to low

**Example:**

```py
from vtki import examples
mesh = examples.load_uniform()
mesh.plot(opacity='linear')
```

![download](https://user-images.githubusercontent.com/22067021/54485012-2a349100-4837-11e9-8c41-46a523c08541.png)
