### PR TITLE
Fix overwrite segfault issues

### DIFF
--- a/vtki/common.py
+++ b/vtki/common.py
@@ -11,7 +11,7 @@ from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 import vtki
 from vtki import DataSetFilters
 from vtki.utilities import (CELL_DATA_FIELD, POINT_DATA_FIELD, get_scalar,
-                            vtk_bit_array_to_char)
+                            vtk_bit_array_to_char, is_vtki_obj)
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
@@ -829,6 +829,20 @@ class Common(DataSetFilters, object):
     def __repr__(self):
         """Object representation"""
         return self.head(display=False)
+
+    def overwrite(self, mesh):
+        """
+        Overwrites this mesh inplace with the new mesh's geometries and data
+
+        Parameters
+        ----------
+        mesh : vtk.vtkDataSet
+            The overwriting mesh.
+
+        """
+        self.DeepCopy(mesh)
+        if is_vtki_obj(mesh):
+            self.copy_meta_from(mesh)
 
 
 class _ScalarsDict(dict):


### PR DESCRIPTION
Anytime I used the `vtki.PolyData.clean` filter or the `overwrite` method, I get a segfault. 

Prior to these changes, the following code would segfault for me - now it works:

```py
from vtki import examples
mesh = examples.download_lidar()
mesh.clean(merge_tol=1)
mesh.plot()
```

@akaszynski: do these changes look okay to you?