### PR TITLE
now using vtklightkit

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -373,6 +373,12 @@ class BasePlotter(object):
         # Add self to open plotters
         _OPEN_PLOTTERS[str(hex(id(self)))] = self
 
+        # lighting style
+        self.lighting = vtk.vtkLightKit()
+        for renderer in self.renderers:
+            self.lighting.AddLightsToRenderer(renderer)
+            renderer.LightFollowCameraOn()
+
     def update_style(self):
         if not hasattr(self, '_style'):
             self._style = vtk.vtkInteractorStyleTrackballCamera()
@@ -2612,6 +2618,7 @@ class Plotter(BasePlotter):
             self.ren_win.SetOffScreenRendering(1)
         else:  # Allow user to interact
             self.iren = vtk.vtkRenderWindowInteractor()
+            self.iren.LightFollowCameraOff()
             self.iren.SetDesiredUpdateRate(30.0)
             self.iren.SetRenderWindow(self.ren_win)
             self.enable_trackball_style()

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -375,6 +375,8 @@ class BasePlotter(object):
 
         # lighting style
         self.lighting = vtk.vtkLightKit()
+        # self.lighting.SetHeadLightWarmth(1.0)
+        # self.lighting.SetHeadLightWarmth(1.0)
         for renderer in self.renderers:
             self.lighting.AddLightsToRenderer(renderer)
             renderer.LightFollowCameraOn()
@@ -553,7 +555,7 @@ class BasePlotter(object):
                  multi_colors=False, name=None, texture=None,
                  render_points_as_spheres=None,
                  render_lines_as_tubes=False, edge_color='black',
-                 ambient=0.2, show_scalar_bar=True, nan_color=None,
+                 ambient=0.0, show_scalar_bar=True, nan_color=None,
                  nan_opacity=1.0, loc=None, backface_culling=False,
                  rgb=False, **kwargs):
         """
@@ -678,6 +680,11 @@ class BasePlotter(object):
         actor: vtk.vtkActor
             VTK actor of the mesh.
         """
+        # fixes lighting issue when using precalculated normals
+        if isinstance(mesh, vtk.vtkPolyData):
+            if mesh.GetPointData().HasArray('Normals'):
+                mesh.point_arrays['Normals'] = mesh.point_arrays.pop('Normals')
+
         if scalar_bar_args is None:
             scalar_bar_args = {}
 

--- a/vtki/renderer.py
+++ b/vtki/renderer.py
@@ -22,6 +22,7 @@ class Renderer(vtkRenderer):
         self.camera_set = False
         self.bounding_box_actor = None
         self.scale = [1.0, 1.0, 1.0]
+        self.AutomaticLightCreationOff()
 
         if border:
             self.add_border(border_color, border_width)


### PR DESCRIPTION
Lighting is better, but it's still not tracking the camera all the time.  It's possible to get the camera in a position where the lighting stays locked relative to the camera, but at other times it still moves around.  It's strange behavior and only occurs when the "y-axis" is perpendicular to the view direction.  Basically, if you're rotating around the y-axis, you get the expected lighting behavior.  Otherwise the lighting stays locked with the scene.

@banesullivan: Let me know if you see any reason why this isn't working.  According to the VTK documentation, you have to disable light following in the interactive renderer and enable it in the renderer.  I've done that:

```python
self.iren.LightFollowCameraOff()
self.renderer.LightFollowCameraOn()
```

![axis_rot](https://user-images.githubusercontent.com/11981631/54676559-3a7f9100-4b01-11e9-8ef0-153a3945a394.gif)
