### PR TITLE
Refactor add_bounds_axes -> show_bounds

### DIFF
--- a/docs/examples/quick/plot/plot-ipython.rst
+++ b/docs/examples/quick/plot/plot-ipython.rst
@@ -40,7 +40,7 @@ that you can manipulate in real time from the Jupyter notebook:
     plotter.add_mesh(dataset)
 
     # Then in another cell, you can add more to the plotter
-    plotter.add_bounds_axes()
+    plotter.show_bounds()
 
 
 Background Plotting
@@ -64,7 +64,7 @@ the :class:`vtki.BackgroundPlotter`:
 
     p.add_mesh(dataset)
 
-    p.add_bounds_axes(grid=True, location='back')
+    p.show_bounds(grid=True, location='back')
 
 
 IPython Interactive Plotting Tools

--- a/docs/examples/quick/plot/plot-multi-window.rst
+++ b/docs/examples/quick/plot/plot-multi-window.rst
@@ -33,7 +33,7 @@ the subplot you wish to be the active subplot.
     plotter.subplot(1, 1)
     plotter.add_text('Render Window 3', font_size=30)
     plotter.add_mesh(vtki.Cone(), color='g', show_edges=True)
-    plotter.add_bounds_axes(all_edges=True)
+    plotter.show_bounds(all_edges=True)
 
     # Display the window
     plotter.show(screenshot='multi-window.png')

--- a/notebooks/Background-Plotting.ipynb
+++ b/notebooks/Background-Plotting.ipynb
@@ -100,7 +100,7 @@
    "source": [
     "#NBVAL_SKIP\n",
     "oa = plotter.add_mesh(grid.outline())\n",
-    "plotter.add_bounds_axes()"
+    "plotter.show_bounds()"
    ]
   },
   {

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -64,7 +64,7 @@ def test_plot_invalid_style():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires X11")
 def test_plot_bounds_axes_with_no_data():
     plotter = vtki.Plotter()
-    plotter.add_bounds_axes()
+    plotter.show_bounds()
     plotter.close()
 
 
@@ -107,9 +107,17 @@ def test_plot_no_active_scalars():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires X11")
-def test_plot_add_bounds_axes():
+def test_plot_show_bounds():
     plotter = vtki.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
+    plotter.show_bounds(show_xaxis=False,
+                        show_yaxis=False,
+                        show_zaxis=False,
+                        show_xlabels=False,
+                        show_ylabels=False,
+                        show_zlabels=False,
+                        use_2d=True)
+    # And test backwards compatibility
     plotter.add_bounds_axes(show_xaxis=False,
                             show_yaxis=False,
                             show_zaxis=False,
@@ -123,19 +131,19 @@ def test_plot_add_bounds_axes():
 def test_plot_label_fmt():
     plotter = vtki.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
-    plotter.add_bounds_axes(xlabel='My X', fmt=r'%.3f')
+    plotter.show_bounds(xlabel='My X', fmt=r'%.3f')
     plotter.plot()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires X11")
 @pytest.mark.parametrize('grid', [True, 'both', 'front', 'back'])
 @pytest.mark.parametrize('location', ['all', 'origin', 'outer', 'front', 'back'])
-def test_plot_add_bounds_axes_params(grid, location):
+def test_plot_show_bounds_params(grid, location):
     plotter = vtki.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
-    plotter.add_bounds_axes(grid=grid, ticks='inside', location=location)
-    plotter.add_bounds_axes(grid=grid, ticks='outside', location=location)
-    plotter.add_bounds_axes(grid=grid, ticks='both', location=location)
+    plotter.show_bounds(grid=grid, ticks='inside', location=location)
+    plotter.show_bounds(grid=grid, ticks='outside', location=location)
+    plotter.show_bounds(grid=grid, ticks='both', location=location)
     plotter.show()
 
 
@@ -485,7 +493,7 @@ def test_multi_renderers():
     plotter.add_mesh(vtki.Cone(), color='g', loc=loc, show_edges=True,
                      backface_culling=True)
     plotter.add_bounding_box(render_lines_as_tubes=True, line_width=5)
-    plotter.add_bounds_axes(all_edges=True)
+    plotter.show_bounds(all_edges=True)
 
     plotter.update_bounds_axes()
     plotter.plot()

--- a/vtki/ipy_tools.py
+++ b/vtki/ipy_tools.py
@@ -170,7 +170,7 @@ class InteractiveTool(object):
                     loc=self.loc)
         # add the axis labels
         if show_bounds:
-            self.plotter.add_bounds_axes(reset_camera=False, loc=loc)
+            self.plotter.show_bounds(reset_camera=False, loc=loc)
         if reset_camera:
             cpos = self.plotter.get_default_cam_pos()
             self.plotter.camera_position = cpos

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1308,7 +1308,7 @@ class BasePlotter(object):
 
     def add_bounds_axes(self, *args, **kwargs):
         """Deprecated"""
-        logging.warning('`add_bounds_axes` is deprecaed. Use `show_bounds` or `show_grid`.')
+        logging.warning('`add_bounds_axes` is deprecated. Use `show_bounds` or `show_grid`.')
         return self.show_bounds(*args, **kwargs)
 
     def add_bounding_box(self, color=None, corner_factor=0.5, line_width=None,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -227,7 +227,7 @@ def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
         if kwargs.get('show_grid', False):
             plotter.show_grid()
         else:
-            plotter.add_bounds_axes()
+            plotter.show_bounds()
 
     if cpos is None:
         cpos = plotter.get_default_cam_pos()
@@ -1175,7 +1175,7 @@ class BasePlotter(object):
         self._active_renderer_index = self.loc_to_index(loc)
         return self.renderers[self._active_renderer_index].add_axes_at_origin()
 
-    def add_bounds_axes(self, mesh=None, bounds=None, show_xaxis=True,
+    def show_bounds(self, mesh=None, bounds=None, show_xaxis=True,
                         show_yaxis=True, show_zaxis=True, show_xlabels=True,
                         show_ylabels=True, show_zlabels=True, italic=False,
                         bold=True, shadow=False, font_size=None,
@@ -1296,7 +1296,7 @@ class BasePlotter(object):
         >>> mesh = vtki.Sphere()
         >>> plotter = vtki.Plotter()
         >>> _ = plotter.add_mesh(mesh)
-        >>> _ = plotter.add_bounds_axes(grid='front', location='outer', all_edges=True)
+        >>> _ = plotter.show_bounds(grid='front', location='outer', all_edges=True)
         >>> plotter.show() # doctest:+SKIP
         """
         kwargs = locals()
@@ -1304,7 +1304,12 @@ class BasePlotter(object):
         _ = kwargs.pop('loc')
         self._active_renderer_index = self.loc_to_index(loc)
         renderer = self.renderers[self._active_renderer_index]
-        renderer.add_bounds_axes(**kwargs)
+        renderer.show_bounds(**kwargs)
+
+    def add_bounds_axes(self, *args, **kwargs):
+        """Deprecated"""
+        logging.warning('`add_bounds_axes` is deprecaed. Use `show_bounds` or `show_grid`.')
+        return self.show_bounds(*args, **kwargs)
 
     def add_bounding_box(self, color=None, corner_factor=0.5, line_width=None,
                          opacity=1.0, render_lines_as_tubes=False, lighting=None,
@@ -1391,7 +1396,7 @@ class BasePlotter(object):
 
     def show_grid(self, **kwargs):
         """
-        A wrapped implementation of ``add_bounds_axes`` to change default
+        A wrapped implementation of ``show_bounds`` to change default
         behaviour to use gridlines and showing the axes labels on the outer
         edges. This is intended to be silimar to ``matplotlib``'s ``grid``
         function.
@@ -1399,7 +1404,7 @@ class BasePlotter(object):
         kwargs.setdefault('grid', 'back')
         kwargs.setdefault('location', 'outer')
         kwargs.setdefault('ticks', 'both')
-        return self.add_bounds_axes(**kwargs)
+        return self.show_bounds(**kwargs)
 
     def set_scale(self, xscale=None, yscale=None, zscale=None, reset_camera=True):
         """

--- a/vtki/qt_plotting.py
+++ b/vtki/qt_plotting.py
@@ -386,7 +386,7 @@ class BackgroundPlotter(QtInteractor):
         orien_menu.addAction('Hide', self.hide_axes)
         # Bounds axes
         axes_menu = view_menu.addMenu('Bounds Axes')
-        axes_menu.addAction('Add Bounds Axes (front)', self.add_bounds_axes)
+        axes_menu.addAction('Add Bounds Axes (front)', self.show_bounds)
         axes_menu.addAction('Add Bounds Grid (back)', self.show_grid)
         axes_menu.addAction('Add Bounding Box', self.add_bounding_box)
         axes_menu.addSeparator()

--- a/vtki/renderer.py
+++ b/vtki/renderer.py
@@ -2,6 +2,7 @@
 Module containing vtki implementation of vtkRenderer
 """
 import collections
+import logging
 import vtk
 from weakref import proxy
 
@@ -139,7 +140,7 @@ class Renderer(vtkRenderer):
         self.parent._actors[str(hex(id(self.marker_actor)))] = self.marker_actor
         return self.marker_actor
 
-    def add_bounds_axes(self, mesh=None, bounds=None, show_xaxis=True,
+    def show_bounds(self, mesh=None, bounds=None, show_xaxis=True,
                         show_yaxis=True, show_zaxis=True, show_xlabels=True,
                         show_ylabels=True, show_zlabels=True, italic=False,
                         bold=True, shadow=False, font_size=None,
@@ -260,7 +261,7 @@ class Renderer(vtkRenderer):
         >>> mesh = vtki.Sphere()
         >>> plotter = vtki.Plotter()
         >>> _ = plotter.add_mesh(mesh)
-        >>> _ = plotter.add_bounds_axes(grid='front', location='outer', all_edges=True)
+        >>> _ = plotter.show_bounds(grid='front', location='outer', all_edges=True)
         >>> plotter.show() # doctest:+SKIP
         """
         self.remove_bounds_axes()
@@ -409,6 +410,11 @@ class Renderer(vtkRenderer):
             cube_axes_actor.SetZLabelFormat(fmt)
 
         return cube_axes_actor
+
+    def add_bounds_axes(self, *args, **kwargs):
+        """Deprecated"""
+        logging.warning('`add_bounds_axes` is deprecaed. Use `show_bounds` or `show_grid`.')
+        return self.show_bounds(*args, **kwargs)
 
     def remove_bounding_box(self):
         """ Removes bounding box """

--- a/vtki/renderer.py
+++ b/vtki/renderer.py
@@ -413,7 +413,7 @@ class Renderer(vtkRenderer):
 
     def add_bounds_axes(self, *args, **kwargs):
         """Deprecated"""
-        logging.warning('`add_bounds_axes` is deprecaed. Use `show_bounds` or `show_grid`.')
+        logging.warning('`add_bounds_axes` is deprecated. Use `show_bounds` or `show_grid`.')
         return self.show_bounds(*args, **kwargs)
 
     def remove_bounding_box(self):


### PR DESCRIPTION
Refactor `add_bounds_axes` -> `show_bounds`. This naming convention is more consistent with the rest of the plotting code (e.g. `show_grid` and `show_axes`)

This maintains backward compatibility and throws a logging warning for `add_bounds_axes`