### PR TITLE
Add user data directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 imageio<=2.4.1
 vtk
 matplotlib
+appdirs

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ with io_open(version_file, mode='r') as fd:
 
 # pre-compiled vtk available for python3
 install_requires = ['numpy',
-                    'imageio']
+                    'imageio',
+                    'appdirs',
+                    ]
 
 # add vtk if not windows and 2.7
 py_ver = int(sys.version[0])

--- a/vtki/__init__.py
+++ b/vtki/__init__.py
@@ -55,3 +55,15 @@ REPR_VOLUME_MAX_CELLS = 1e6
 
 # Set where figures are saved
 FIGURE_PATH = None
+
+# Set up data directory
+import appdirs
+import os
+
+USER_DATA_PATH = appdirs.user_data_dir('vtki')
+if not os.path.exists(USER_DATA_PATH):
+    os.makedirs(USER_DATA_PATH)
+
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')
+if not os.path.exists(EXAMPLES_PATH):
+    os.makedirs(EXAMPLES_PATH)

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -6,19 +6,22 @@ import sys
 
 import vtki
 
-
-DOWNLOAD_TEMP_FOLDER = True
-"""
-A flag to save downloads in a temporary directory or the current working
-directory.
-"""
-
 # Helpers:
+
+def delete_downloads():
+    """Delete all downloaded examples to free space or update the files"""
+    shutil.rmtree(vtki.EXAMPLES_PATH)
+    os.makedirs(vtki.EXAMPLES_PATH)
+    return True
 
 def _get_vtk_file_url(filename):
     return 'https://github.com/vtkiorg/vtk-data/raw/master/Data/{}'.format(filename)
 
 def _retrieve_file(url, filename):
+    # First check if file has already been downloaded
+    local_path = os.path.join(vtki.EXAMPLES_PATH, filename)
+    if os.path.isfile(local_path):
+        return local_path, None
     # grab the correct url retriever
     if sys.version_info < (3,):
         import urllib
@@ -26,13 +29,11 @@ def _retrieve_file(url, filename):
     else:
         import urllib.request
         urlretrieve = urllib.request.urlretrieve
-    if DOWNLOAD_TEMP_FOLDER:
-        saved_file, resp = urlretrieve(url)
-        # rename saved file:
-        new_name = saved_file.replace(os.path.basename(saved_file), os.path.basename(filename))
-        shutil.move(saved_file, new_name)
-        return new_name, resp
-    return urlretrieve(url, filename)
+    # Perfrom download
+    saved_file, resp = urlretrieve(url)
+    # new_name = saved_file.replace(os.path.basename(saved_file), os.path.basename(filename))
+    shutil.move(saved_file, local_path)
+    return local_path, resp
 
 def _download_file(filename):
     url = _get_vtk_file_url(filename)


### PR DESCRIPTION
Resolve #142 via https://github.com/vtkiorg/vtki/issues/142#issuecomment-475694139

This makes a `vtki` user data directory where examples can be downloaded and saved so that they do not have to be repeatedly downloaded every time `download_*` is called. There is also an `examples.delete_downloads()` function included to help users delete/refresh the example files.