### PR TITLE
Add array setter/getter to vtki.Common

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -14,7 +14,7 @@ py2 = sys.version_info.major == 2
 
 def test_point_arrays():
     key = 'test_array'
-    grid.point_arrays[key] = np.arange(grid.n_points)
+    grid[key] = np.arange(grid.n_points)
     assert key in grid.point_arrays
 
     orig_value = grid.point_arrays[key][0]/1.0
@@ -27,6 +27,8 @@ def test_point_arrays():
     grid.point_arrays[key] = np.arange(grid.n_points)
     assert key in grid.point_arrays
 
+    assert np.allclose(grid[key], np.arange(grid.n_points))
+
 
 def test_point_arrays_bad_value():
     with pytest.raises(TypeError):
@@ -38,7 +40,7 @@ def test_point_arrays_bad_value():
 
 def test_cell_arrays():
     key = 'test_array'
-    grid.cell_arrays[key] = np.arange(grid.n_cells)
+    grid[key] = np.arange(grid.n_cells)
     assert key in grid.cell_arrays
 
     orig_value = grid.cell_arrays[key][0]/1.0
@@ -50,6 +52,8 @@ def test_cell_arrays():
 
     grid.cell_arrays[key] = np.arange(grid.n_cells)
     assert key in grid.cell_arrays
+
+    assert np.allclose(grid[key], np.arange(grid.n_cells))
 
 
 def test_cell_arrays_bad_value():

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -1,6 +1,7 @@
 """
 Attributes common to PolyData and Grid Objects
 """
+import collections
 import logging
 from weakref import proxy
 
@@ -706,10 +707,16 @@ class Common(DataSetFilters, object):
         return get_scalar(self, name, preference=preference, info=info)
 
 
-    def __getitem__(self, name):
-        """Get an array by name"""
-        # TODO: can we implement a way for the user to set the preference?
-        return self.get_scalar(name, preference='cell', info=False)
+    def __getitem__(self, index):
+        """ Searches both point and cell data for an array """
+        if isinstance(index, collections.Iterable) and not isinstance(index, str):
+            name, preference = index[0], index[1]
+        elif isinstance(index, str):
+            name = index
+            preference = 'cell'
+        else:
+            raise KeyError('Index ({}) not understood. Index must be a string name or a tuple of string name and string preference.'.format(index))
+        return self.get_scalar(name, preference=preference, info=False)
 
     def __setitem__(self, name, scalars):
         """Add/set an array in the point_arrays or cell_arrays field depending

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -16,7 +16,8 @@ from vtk.util import numpy_support as VN
 
 import vtki
 from vtki.export import export_plotter_vtkjs
-from vtki.utilities import get_scalar, is_vtki_obj, numpy_to_texture, wrap
+from vtki.utilities import (get_scalar, is_vtki_obj, numpy_to_texture, wrap,
+                            _raise_not_matching)
 
 _ALL_PLOTTERS = {}
 
@@ -115,13 +116,6 @@ def run_from_ipython():
     except NameError:
         return False
 
-
-def _raise_not_matching(scalars, mesh):
-    raise Exception('Number of scalars (%d) ' % scalars.size +
-                    'must match either the number of points ' +
-                    '(%d) ' % mesh.GetNumberOfPoints() +
-                    'or the number of cells ' +
-                    '(%d) ' % mesh.GetNumberOfCells())
 
 
 def opacity_transfer_function(key, n_colors):

--- a/vtki/utilities.py
+++ b/vtki/utilities.py
@@ -303,3 +303,11 @@ def fit_plane_to_points(points, return_meta=False):
     if return_meta:
         return plane, center, normal
     return plane
+
+
+def _raise_not_matching(scalars, mesh):
+    raise Exception('Number of scalars (%d) ' % scalars.size +
+                    'must match either the number of points ' +
+                    '(%d) ' % mesh.n_points +
+                    'or the number of cells ' +
+                    '(%d) ' % mesh.n_cells)


### PR DESCRIPTION
This implements `__getitem__`/`__setitem__` on `vtki.Common`

A lot of new users are getting confused by the `.point_arrays` and `.cell_arrays` dictionaries and having trouble keeping track of where their data resides. Particularly, this can get confusing if one uses the `.cell_data_to_point_data` or `.point_data_to_cell_data` filters.

I propose we implement a `__getitem__` method on the `vtki.Common` class that will search the arrays in both `.point_arrays` and `.cell_arrays` for what the user asks for (note that this is already implemented in `.get_scalar`). This also comes with a `__setitem__` method that uses the length of the array to decide on where it belongs.

Overall, this makes usage of scalars in `vtki` simpler and more intuitive for new users.


```py
from vtki import examples
import numpy as np

data = examples.load_uniform()

# Assign arrays
data['foo'] = np.random.random(data.n_cells)
data['foo'] = np.random.random(data.n_points)
```
```py
>>> # Fetch arrays
>>> len(data['foo']) # defaults to cell preference
729
>>> len(data['foo', 'points'])
1000
>>> len(data['foo', 'cells'])
729
```