### PR TITLE
Resample with dataset

### DIFF
--- a/examples/01-filter/resample.py
+++ b/examples/01-filter/resample.py
@@ -1,0 +1,34 @@
+"""
+Resampling Data Sets
+~~~~~~~~~~~~~~~~~~~~
+
+Resample one mesh's point/cell arrays onto another meshes nodes.
+"""
+###############################################################################
+# This example will resample a volumetric mesh's  scalar data onto the surface
+# of a sphere contained in that volume.
+
+# sphinx_gallery_thumbnail_number = 1
+import vtki
+from vtki import examples
+import numpy as np
+
+###############################################################################
+# Querry a grids points onto a sphere
+mesh = vtki.Sphere(center=(4.5,4.5,4.5), radius=4.5)
+data_to_probe = examples.load_uniform()
+
+###############################################################################
+# Plot the two datasets
+p = vtki.Plotter()
+p.add_mesh(mesh, color=True)
+p.add_mesh(data_to_probe, opacity=0.5)
+p.show()
+
+###############################################################################
+# Run the algorithm and plot the result
+result = mesh.interpolate(data_to_probe)
+
+# Plot result
+name = 'Spatial Point Data'
+result.plot(scalars=name, clim=data_to_probe.get_data_range(name))

--- a/examples/01-filter/resample.py
+++ b/examples/01-filter/resample.py
@@ -27,7 +27,7 @@ p.show()
 
 ###############################################################################
 # Run the algorithm and plot the result
-result = mesh.interpolate(data_to_probe)
+result = mesh.sample(data_to_probe)
 
 # Plot result
 name = 'Spatial Point Data'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -306,7 +306,7 @@ def test_smooth():
 def test_resample():
     mesh = vtki.Sphere(center=(4.5,4.5,4.5), radius=4.5)
     data_to_probe = examples.load_uniform()
-    result = mesh.interpolate(data_to_probe)
+    result = mesh.sample(data_to_probe)
     name = 'Spatial Point Data'
     assert name in result.scalar_names
     assert isinstance(result, type(mesh))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -300,4 +300,13 @@ def test_smooth():
     vol = data.threshold_percent(30)
     surf = vol.extract_geometry()
     smooth = surf.smooth()
-    assert np.any(smooth)
+    assert np.any(smooth.points)
+
+
+def test_resample():
+    mesh = vtki.Sphere(center=(4.5,4.5,4.5), radius=4.5)
+    data_to_probe = examples.load_uniform()
+    result = mesh.interpolate(data_to_probe)
+    name = 'Spatial Point Data'
+    assert name in result.scalar_names
+    assert isinstance(result, type(mesh))

--- a/vtki/filters.py
+++ b/vtki/filters.py
@@ -940,19 +940,19 @@ class DataSetFilters(object):
         alg.Update()
         return _get_output(alg)
 
-    def interpolate(dataset, target, tolerance=None, pass_cell_arrays=True,
+    def sample(dataset, target, tolerance=None, pass_cell_arrays=True,
                     pass_point_arrays=True):
-        """Resample (interpolate) scalar data between from a mesh onto this mesh
+        """Resample scalar data between from a mesh onto this mesh
         using :class:`vtk.vtkResampleWithDataSet`.
 
         Parameters
         ----------
         dataset: vtki.Common
-            The source vtk data object as the mesh to interpolate values on to
+            The source vtk data object as the mesh to sample values on to
 
         target: vtki.Common
-            The vtk data object to interpolate from - point and cell arrays from
-            this object are interpolated onto the nodes of the ``dataset`` mesh
+            The vtk data object to sample from - point and cell arrays from
+            this object are sampled onto the nodes of the ``dataset`` mesh
 
         tolerance: flaot, optional
             tolerance used to compute whether a point in the source is in a
@@ -965,8 +965,8 @@ class DataSetFilters(object):
             Preserve source mesh's original point data arrays
         """
         alg = vtk.vtkResampleWithDataSet() # Construct the ResampleWithDataSet object
-        alg.SetInputData(dataset)  # Set the Input data (actually the source i.e. where to interpolate from)
-        alg.SetSourceData(target) # Set the Source data (actually the target, i.e. where to interpolate to)
+        alg.SetInputData(dataset)  # Set the Input data (actually the source i.e. where to sample from)
+        alg.SetSourceData(target) # Set the Source data (actually the target, i.e. where to sample to)
         alg.SetPassCellArrays(pass_cell_arrays)
         alg.SetPassPointArrays(pass_point_arrays)
         if tolerance is not None:

--- a/vtki/filters.py
+++ b/vtki/filters.py
@@ -940,19 +940,36 @@ class DataSetFilters(object):
         alg.Update()
         return _get_output(alg)
 
-    def interpolate(source, target):
+    def interpolate(dataset, target, tolerance=None, pass_cell_arrays=True,
+                    pass_point_arrays=True):
         """Interpolate data between two vtk objects using vtkResampleWithDataSet.
 
         Parameters
         ----------
-        source: The vtk data object to take the data from.
+        dataset: vtki.Common
+            The source vtk data object as the mesh to interpolate values on to
 
-        target: The vtk data object to interpolate on to.
+        target: vtki.Common
+            The vtk data object to interpolate from - point and cell arrays from
+            this object are interpolated onto the nodes of the ``dataset`` mesh
+
+        tolerance: flaot, optional
+            tolerance used to compute whether a point in the source is in a
+            cell of the input.  If not given, tolerance automatically generated.
+
+        pass_cell_arrays: bool, optional
+            Preserve source mesh's original cell data arrays
+
+        pass_point_arrays: bool, optional
+            Preserve source mesh's original point data arrays
         """
         alg = vtk.vtkResampleWithDataSet() # Construct the ResampleWithDataSet object
-        alg.SetInputData(source)  # Set the Input data (actually the source i.e. where to interpolate from)
+        alg.SetInputData(dataset)  # Set the Input data (actually the source i.e. where to interpolate from)
         alg.SetSourceData(target) # Set the Source data (actually the target, i.e. where to interpolate to)
+        alg.SetPassCellArrays(pass_cell_arrays)
+        alg.SetPassPointArrays(pass_point_arrays)
+        if tolerance is not None:
+            alg.SetComputeTolerance(False)
+            alg.SetTolerance(tolerance)
         alg.Update() # Perfrom the resampling
-        output = _get_output(alg)
-        return output
-
+        return _get_output(alg)

--- a/vtki/filters.py
+++ b/vtki/filters.py
@@ -942,7 +942,8 @@ class DataSetFilters(object):
 
     def interpolate(dataset, target, tolerance=None, pass_cell_arrays=True,
                     pass_point_arrays=True):
-        """Interpolate data between two vtk objects using vtkResampleWithDataSet.
+        """Resample (interpolate) scalar data between from a mesh onto this mesh
+        using :class:`vtk.vtkResampleWithDataSet`.
 
         Parameters
         ----------


### PR DESCRIPTION
Note this is an expansion of @ascillitoe's #171 

Add a filter to resample some other dataset onto a mesh's points... naming might be tricky here. Note that this will be implemented under `vtki.DataSetFilters` as a filtering method so you could call the function and pass it another mesh that you like to probe.

I like @ascillitoe's naming suggestion of `.interpolate` but I want to make sure this makes sense - @akaszynski, thoughts?

Usage:

```py
import vtki
from vtki import examples
import numpy as np

# Querry a grids points onto a sphere
mesh = vtki.Sphere(center=(4.5,4.5,4.5), radius=4.5)
data_to_probe = examples.load_uniform()

# Plot the two datasets
p = vtki.Plotter()
p.add_mesh(mesh, color=True)
p.add_mesh(data_to_probe, opacity=0.5)
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/56236169-33876800-6046-11e9-9fd2-c7d88383e126.png)


```py
# Run the algorithm
result = mesh.sample(data_to_probe)

# Plot result
result.plot(scalars='Spatial Point Data')
```

![download](https://user-images.githubusercontent.com/22067021/56236173-35512b80-6046-11e9-9975-54f66f0c960f.png)

