### PR TITLE
Fix set_position bug

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -375,7 +375,7 @@ class BasePlotter(object):
         self._actors = {}
         # track if the camera has been setup
         # self.camera_set = False
-        self.first_time = True
+        self._first_time = True
         # Keep track of the scale
         self._labels = []
 
@@ -477,12 +477,15 @@ class BasePlotter(object):
         self.camera.SetFocalPoint(point)
         self._render()
 
-    def set_position(self, point):
+    def set_position(self, point, reset=False):
         """ sets camera position to a point """
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()
         self.camera.SetPosition(point)
+        if reset:
+            self.reset_camera()
+        self.camera_set = True
         self._render()
 
     def set_viewup(self, vector):
@@ -498,7 +501,7 @@ class BasePlotter(object):
         if hasattr(self, 'ren_win'):
             if hasattr(self, 'render_trigger'):
                 self.render_trigger.emit()
-            elif not self.first_time:
+            elif not self._first_time:
                 self.render()
 
     def add_axes(self, interactive=None, color=None):
@@ -2834,12 +2837,12 @@ class Plotter(BasePlotter):
         if use_panel is None:
             use_panel = rcParams['use_panel']
         # reset unless camera for the first render unless camera is set
-        if self.first_time:  # and not self.camera_set:
+        if self._first_time:  # and not self.camera_set:
             for renderer in self.renderers:
                 if not renderer.camera_set:
                     renderer.camera_position = renderer.get_default_cam_pos()
                     renderer.ResetCamera()
-            self.first_time = False
+            self._first_time = False
 
         if title:
             self.ren_win.SetWindowName(title)


### PR DESCRIPTION
Thanks, @GuillaumeFavelier for pointing this out!

These changes fix a bug where calling `Plotter.set_position` would be overridden by the `Plotter.show()` call's preference for a default isometric view.

Test it out with:

```py
import vtki
plt = vtki.Plotter(notebook=1)
plt.add_mesh(vtki.Cone())
plt.set_position([0, 0, 5], reset=True)
plt.show(use_panel=False)
print(plt.camera_position)
```
![download](https://user-images.githubusercontent.com/22067021/56366637-d0661480-61b0-11e9-9bb2-1a2ab295e512.png)
```txt
[(0.0, 0.0, 3.2036135254332487), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
```

## Nuanced Behavior

Note that this has a pretty different result from using the `camera_position` setter which calls `Plotter.view_vector`

```py
import vtki
plt = vtki.Plotter(notebook=1)
plt.add_mesh(vtki.Cone())
plt.camera_position = [0,0,5]
plt.show(use_panel=False)
print(plt.camera_position)
```
![download](https://user-images.githubusercontent.com/22067021/56366737-099e8480-61b1-11e9-8d6f-e4c150a0e3e1.png)

```txt
[(0.0, 0.0, 3.2036135254332487), (0.0, 0.0, 0.0), (-1.0, 0.0, 0.0)]
```


Thoughts on the differences in behavior here, @GuillaumeFavelier and @akaszynski?