### PR TITLE
Use gl-ci-helpers on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 sudo: required
-
 dist: xenial
-
 os:
   - linux
-
 language: python
-
 python:
   - '3.5'
   - '3.6'
   - '3.7'
-
-addons:
-  apt:
-    packages:
-      - xvfb
-
 env:
   global:
     # Doctr deploy key for vtkiorg/vtki
@@ -28,13 +18,9 @@ before_script:
   - echo $TRAVIS_BRANCH
   - echo $TRAVIS_BUILD_NUMBER
   - echo $TRAVIS_REPO_SLUG
-  # configure a headless display to test plot generation
-  - export DISPLAY=:99.0
-  - which Xvfb
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-  # - ls -l /etc/init.d/
-  # - sh -e /etc/init.d/xvfb start
-  - sleep 3 # give xvfb some time to start
+  # configure a headless display
+  - git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git
+  - sh gl-ci-helpers/travis/setup_headless_display.sh
 
 install:
   - pip install -r requirements.txt
@@ -48,6 +34,8 @@ install:
   - pip list
 
 script:
+  # unset VTKI_OFFSCREEN which is set by travis CI helper
+  - unset VTKI_OFFSCREEN
   # Run the test suite and generate coverage report
   - pytest -v --cov vtki
   # Run all code examples in the docstrings

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - echo $TRAVIS_REPO_SLUG
   # configure a headless display
   - git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git
-  - sh gl-ci-helpers/travis/setup_headless_display.sh
+  - source ./gl-ci-helpers/travis/setup_headless_display.sh
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,7 @@ env:
     # Doctr deploy key for vtkiorg/vtki
     - secure: "NHUV04B//rkOUxfBd5Bk3QN3g/iQ91wdRZowNTwCIPAbznFez2mbwQcsULDeZk7blPsv1xEAnqy/T/nPyYZuHO9qU2/OElvxKspaKgcGZ9Ig/czmjrO7Y5VnU2KOZJNwBLgb6mEpDvkKoI2j9WhhcTuPcDbayk6ntXz03snYRUsn2nwHfvqDmIqMQnqSwgVejPJQxBsQSikzYzkTYT9P/z94VoSTp4UrvDVj2Tygrw4PnSGe/9x6qTolo3Ofd+REt4LBth6/lBX2OrBhHwnp9wWpEX1o98HOdf5ZUHI9v8gZacnncVXNlNu1biBlQR58bXZX/4RqRdM2No6NcszC8CbhAS+UhNdsPlbimt9L60s4MWwq+IaxCOA2/lzLVdFl8p5wDjz+DDZsdVMNyjhO3MBP5Am/4qJ0BsQEQ2vtZMF3Jvil9oiSSWcp7IGYsj3aPqEcKFm5uc2SwU1CXg4uBfgDsowqBi0t5/1rWqsJQ6p+6ZlU2NoN4ppNjuenAYyDla49J6I7wLp6Z3GwHuupE75WncVhL5BY5aYRcTDrkKuRx8nFIMe+Xuzp6NKmWaDxIwoztA0VPZ9FtMYiM5ahvHwSnZ8wIxUngjMHPuE7+e6KkCBcLt/e7DlzBQhi4kPJesbzw3NX/VmYkAoZsK5tkwKBZakKIKudpjzW73DxGE8="
 
-before_script:
-  - echo $TRAVIS_COMMIT
-  - echo $TRAVIS_TAG
-  - echo $TRAVIS_BRANCH
-  - echo $TRAVIS_BUILD_NUMBER
-  - echo $TRAVIS_REPO_SLUG
+before_install:
   # configure a headless display
   - git clone --depth 1 git://github.com/vtkiorg/gl-ci-helpers.git
   - source ./gl-ci-helpers/travis/setup_headless_display.sh
@@ -32,6 +27,13 @@ install:
   - python -c "import vtk; print(vtk.VTK_VERSION)"
   - python -c "import imageio; imageio.plugins.ffmpeg.download()"
   - pip list
+
+before_script:
+  - echo $TRAVIS_COMMIT
+  - echo $TRAVIS_TAG
+  - echo $TRAVIS_BRANCH
+  - echo $TRAVIS_BUILD_NUMBER
+  - echo $TRAVIS_REPO_SLUG
 
 script:
   # unset VTKI_OFFSCREEN which is set by travis CI helper

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -89,10 +89,18 @@ See other examples:
 Running on CI Services
 ~~~~~~~~~~~~~~~~~~~~~~
 
+
+Please head over to `vtkiorg/gl-ci-hepers`_ for details on setting up CI
+services like Travis and AppVeyor to run ``vtki``.
+
+.. _vtkiorg/gl-ci-hepers: https://github.com/vtkiorg/gl-ci-helpers
+
+
+Running on MyBinder
+~~~~~~~~~~~~~~~~~~~
+
 This section is for advanced users that would like to install and use ``vtki``
-with headless displays and Docker containers. The steps here will work for
-using ``vtki`` on Linux based continuous integration services like Travis CI
-and on notebook hosting services like MyBinder_.
+with headless displays on notebook hosting services like MyBinder_.
 
 Please see `this project`_ for a convenient Cookiecutter_ to get started using
 ``vtki`` on the notebook hosting service MyBinder_.
@@ -102,69 +110,44 @@ Please see `this project`_ for a convenient Cookiecutter_ to get started using
 .. _MyBinder: https://mybinder.org
 
 To get started, the Docker container will need to have ``libgl1-mesa-dev`` and
-``xvfb`` installed through and ``apt-get``. In a Travis scripts, simply include
-the following in your ``.travis.yml`` file:
-
-.. code-block:: yaml
-
-    addons:
-      apt:
-        packages:
-          - xvfb
-
-and for MyBinder, include the following in a file called ``apt.txt``::
+``xvfb`` installed through ``apt-get``. For MyBinder, include the following in
+a file called ``apt.txt``::
 
     libgl1-mesa-dev
     xvfb
 
-Then, you need to configure the headless display, on Travis, add this to the
-``.travis.yml`` file:
-
-.. code-block:: yaml
-
-    before_script: # configure a headless display to test plot generation
-      - export DISPLAY=:99.0
-      - export VTKI_OFF_SCREEN=True
-      - which Xvfb
-      - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-      - sleep 3 # give xvfb some time to start
-
-
-Likewise for MyBinder, create a file called ``start`` and include the following
-set up script that will run everytime your Docker container is launched:
+Then, you need to configure the headless display, for MyBinder, create a file
+called ``start`` and include the following set up script that will run every
+time your Docker container is launched:
 
 .. code-block:: bash
 
     #!/bin/bash
+    set -x
     export DISPLAY=:99.0
     export VTKI_OFF_SCREEN=True
     which Xvfb
     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     sleep 3
+    set +x
     exec "$@"
 
 
 And that's it! Include ``vtki`` in your Python requirements and get to
 visualizing your data! If you need more help than this on setting up ``vtki``
-for CI-like services, hop on Slack and chat with the developers or take a look
-at `this repository`_ that is currently using ``vtki`` on MyBinder.
+for these types of services, hop on Slack and chat with the developers or take
+a look at `this repository`_ that is currently using ``vtki`` on MyBinder.
 
 .. _this repository: https://github.com/OpenGeoVis/PVGeo-Examples
 
-.. warning:: Offscreen rendering is required for headless displays
 
-    Note that ``vtki`` will have to be used in offscreen mode. This can be forced on import with:
-
-    .. code-block:: python
-
-        import vtki
-        vtki.OFF_SCREEN = True
-
-
-Running on remote servers
+Running on Remote Servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using ``vtki`` on remote servers requires similar setup steps as in the above Docker case. As an example, here are the complete steps to use ``vtki`` on AWS EC2 Ubuntu 18.04 LTS (``ami-0a313d6098716f372`` in ``us-east-1``). Other servers would work similarly.
+Using ``vtki`` on remote servers requires similar setup steps as in the above
+Docker case. As an example, here are the complete steps to use ``vtki`` on AWS
+EC2 Ubuntu 18.04 LTS (``ami-0a313d6098716f372`` in ``us-east-1``).
+Other servers would work similarly.
 
 After logging into the remote server, install Miniconda and related packages:
 


### PR DESCRIPTION
Use the new gl-ci-helpers repo on Travis builds

This makes sure we are consistently setting up CIs to run `vtki`