### PR TITLE
`QMainWindow` defined twice

### DIFF
--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -13,12 +13,6 @@ from vtki.plotting import system_supports_plotting
 NO_PLOTTING = not system_supports_plotting()
 
 
-
-# dummy class to allow module init
-class QMainWindow(object):
-    pass
-
-
 try:
     import PyQt5
     from PyQt5.Qt import (QMainWindow, QFrame, QVBoxLayout, QAction)


### PR DESCRIPTION
Just a small thing I noticed randomly looking through files - `QMainWindow` is dealt with in the try-except statement, so no need to define it before that.