### PR TITLE
streamlines filter

### DIFF
--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -53,7 +53,7 @@ streamlines, src = mesh.streamlines(return_source=True, source_radius=10,
 
 
 ################################################################################
-boundary = mesh.decimate_boundary()
+boundary = mesh.decimate_boundary().wireframe()
 
 p = vtki.Plotter(notebook=1)
 p.add_mesh(streamlines.tube(radius=0.2), ligthing=False)

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -1,0 +1,65 @@
+"""
+Streamlines
+~~~~~~~~~~~
+
+Integrate a vector field to generate streamlines.
+"""
+################################################################################
+# This example generates streamlines of blood velocity. An isosurface of speed
+# provides context. The starting positions for the streamtubes were determined
+# by experimenting with the data.
+
+# sphinx_gallery_thumbnail_number = 1
+import vtki
+from vtki import examples
+
+################################################################################
+# Download a sample dataset containing a vector field that can be integrated.
+
+mesh = examples.download_carotid()
+
+
+
+################################################################################
+# Run the stream line filtering algorithm.
+
+streamlines, src = mesh.streamlines(return_source=True, max_time=100.0,
+                           initial_step_length=2., terminal_speed=0.1,
+                           n_points=25, source_radius=2.0,
+                           source_center=(133.1, 116.3, 5.0) )
+
+################################################################################
+# Display the results! Please note that because this dataset's velocity field
+# was measured with low resolution, many streamlines travel outside the artery.
+
+p = vtki.Plotter(notebook=1)
+p.add_mesh(mesh.outline(), color='k')
+p.add_mesh(streamlines.tube(radius=0.15))
+p.add_mesh(src)
+p.add_mesh(mesh.contour([160]).wireframe(),
+           color='grey', opacity=0.25)
+p.camera_position = [(182., 177., 50),
+                     (139, 105, 19),
+                     (-0.2, -0.2, 1)]
+p.show()
+
+
+################################################################################
+# Here is another example of blood flow:
+mesh = examples.download_blood_vessels().cell_data_to_point_data()
+mesh.set_active_scalar('velocity')
+streamlines, src = mesh.streamlines(return_source=True, source_radius=10,
+                           source_center=(92.46, 74.37, 135.5) ,)
+
+
+################################################################################
+boundary = mesh.decimate_boundary()
+
+p = vtki.Plotter(notebook=1)
+p.add_mesh(streamlines.tube(radius=0.2), ligthing=False)
+p.add_mesh(src)
+p.add_mesh(boundary, color='grey', opacity=0.25)
+p.camera_position = [(10, 9.5, -43),
+                     (87.0, 73.5, 123.0),
+                     (-0.5, -0.7, 0.5)]
+p.show()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -310,3 +310,13 @@ def test_resample():
     name = 'Spatial Point Data'
     assert name in result.scalar_names
     assert isinstance(result, type(mesh))
+
+
+def test_streamlines():
+    mesh = examples.download_carotid()
+    stream, src = mesh.streamlines(return_source=True, max_time=100.0,
+                            initial_step_length=2., terminal_speed=0.1,
+                           n_points=25, source_radius=2.0,
+                           source_center=(133.1, 116.3, 5.0) )
+    assert stream.n_points > 0
+    assert src.n_points == 25

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -653,6 +653,11 @@ class Common(DataSetFilters, object):
         return list(self.GetBounds())
 
     @property
+    def length(self):
+        """the length of the diagonal of the bounding box"""
+        return self.GetLength()
+
+    @property
     def center(self):
         """ Center of the bounding box """
         return list(self.GetCenter())

--- a/vtki/examples/downloads.py
+++ b/vtki/examples/downloads.py
@@ -137,7 +137,9 @@ def download_blood_vessels():
     """data representing the bifurcation of blood vessels."""
     local_path, _ = _download_file('pvtu_blood_vessels/blood_vessels.zip')
     filename = os.path.join(local_path, 'T0000000500.pvtu')
-    return vtki.read(filename)
+    mesh = vtki.read(filename)
+    mesh.set_active_vectors('velocity')
+    return mesh
 
 def download_iron_pot():
     return _download_and_read('ironProt.vtk')
@@ -279,7 +281,10 @@ def download_spider():
     return _download_and_read('spider.ply')
 
 def download_carotid():
-    return _download_and_read('carotid.vtk')
+    mesh = _download_and_read('carotid.vtk')
+    mesh.set_active_scalar('scalars')
+    mesh.set_active_vectors('vectors')
+    return mesh
 
 def download_blow():
     return _download_and_read('blow.vtk')


### PR DESCRIPTION
Resolve #198 

This adds a `.streamlines()` filter that will integrate a vector field to generate streamlines.

### Todo:

- [x] Document the filter
- [x] Add parameter descriptions

@JiaweiZhuang: would you look over these changes and provide feedback?

### Example A:

```py
import vtki
from vtki import examples
mesh = examples.download_carotid()

streamlines = mesh.streamlines(max_time=100.0,
                           initial_step_length=2., terminal_speed=0.1,
                           n_points=25, source_radius=2.0,
                           source_center=(133.1, 116.3, 5.0) )

p = vtki.Plotter(notebook=1)
p.add_mesh(mesh.outline(), color='k')
p.add_mesh(streamlines.tube(radius=0.15))
p.add_mesh(mesh.contour([160]).wireframe(),
           color='grey', opacity=0.25)
p.camera_position = [(182., 177., 50),
                     (139, 105, 19),
                     (-0.2, -0.2, 1)]
p.show()
```
![sphx_glr_streamlines_001](https://user-images.githubusercontent.com/22067021/56819483-0cc7ef00-6807-11e9-97e1-cca9454e59a9.png)


### Example B:

```py
import vtki
from vtki import examples

mesh = examples.download_blood_vessels().cell_data_to_point_data()
mesh.set_active_scalar('velocity')

streamlines, src = mesh.streamlines(return_source=True, source_radius=10,
                           source_center=(92.46, 74.37, 135.5) ,)

boundary = mesh.decimate_boundary()

p = vtki.Plotter(notebook=1)
p.add_mesh(streamlines.tube(radius=0.2), ligthing=False)
p.add_mesh(src)
p.add_mesh(boundary, color='grey', opacity=0.25)
p.camera_position = [(10, 9.5, -43),
                     (87.0, 73.5, 123.0),
                     (-0.5, -0.7, 0.5)]
p.show()
```

![sphx_glr_streamlines_002](https://user-images.githubusercontent.com/22067021/56819661-6af4d200-6807-11e9-8ef5-4428d26a9fcb.png)