### PR TITLE
Add support for string scalar arrays and beter point labelling

### DIFF
--- a/examples/02-plot/plot-labels.py
+++ b/examples/02-plot/plot-labels.py
@@ -4,23 +4,27 @@ Label Points
 
 Use string arrays in a point set to label points
 """
+# sphinx_gallery_thumbnail_number = 3
 from vtki import examples
 import vtki
 import numpy as np
 
 ###############################################################################
-# Label Array
-# +++++++++++
+# Label String Array
+# ++++++++++++++++++
+#
+# This example will label the nodes of a mesh with a given array of string
+# labels for each of the nodes.
 
+# Make some random points
 poly = vtki.PolyData(np.random.rand(10, 3))
-
-print(poly)
-
 
 ###############################################################################
 # Add string labels to the point data - this associates a label with every node:
 
 poly['My Labels'] = ['Label {}'.format(i) for i in range(poly.n_points)]
+
+print(poly)
 
 ###############################################################################
 # Now plot the points with labels:
@@ -33,10 +37,14 @@ plotter.show()
 ###############################################################################
 # Label Node Locations
 # ++++++++++++++++++++
+#
+# This example will label the nodes of a mesh with their coordinate locations
 
 # Load example beam file
 grid = vtki.UnstructuredGrid(examples.hexbeamfile)
 
+
+###############################################################################
 # Create plotting class and add the unstructured grid
 plotter = vtki.Plotter()
 plotter.add_mesh(grid, show_edges=True, color='tan')
@@ -44,11 +52,38 @@ plotter.add_mesh(grid, show_edges=True, color='tan')
 # Add labels to points on the yz plane (where x == 0)
 points = grid.points
 mask = points[:, 0] == 0
-plotter.add_point_labels(points[mask], points[mask].tolist())
+plotter.add_point_labels(points[mask], points[mask].tolist(),
+                         point_size=20, font_size=36)
 
 plotter.camera_position = [
-                (-1.4643015810492384, 1.5603923627830638, 3.16318236536270),
-                (0.05268120500967251, 0.639442034364944, 1.204095304165153),
-                (0.2364061044392675, 0.9369426029156169, -0.25739213784721)]
+    (-1.5, 1.5, 3.),
+    (0.05, 0.6, 1.2),
+    (0.2, 0.9, -0.25)]
 
 plotter.show()
+
+
+
+###############################################################################
+# Label Scalar Values
+# +++++++++++++++++++
+#
+# This example will label pooints with their scalar values
+
+mesh = examples.load_uniform().slice()
+
+###############################################################################
+p = vtki.Plotter()
+
+# Add the mesh:
+p.add_mesh(mesh, scalars='Spatial Point Data', show_edges=True)
+# Add the points with scalar labels:
+p.add_point_scalar_labels(mesh, 'Spatial Point Data',
+                          point_size=20, font_size=36)
+
+# Use a nice camera position:
+p.camera_position = [(7, 4, 5),
+                     (4.4, 7., 7.2),
+                     (0.8, 0.5, 0.25)]
+
+p.show()

--- a/examples/02-plot/plot-labels.py
+++ b/examples/02-plot/plot-labels.py
@@ -1,0 +1,54 @@
+"""
+Label Points
+~~~~~~~~~~~~
+
+Use string arrays in a point set to label points
+"""
+from vtki import examples
+import vtki
+import numpy as np
+
+###############################################################################
+# Label Array
+# +++++++++++
+
+poly = vtki.PolyData(np.random.rand(10, 3))
+
+print(poly)
+
+
+###############################################################################
+# Add string labels to the point data - this associates a label with every node:
+
+poly['My Labels'] = ['Label {}'.format(i) for i in range(poly.n_points)]
+
+###############################################################################
+# Now plot the points with labels:
+
+plotter = vtki.Plotter()
+plotter.add_point_labels(poly, 'My Labels', point_size=20, font_size=36)
+plotter.show()
+
+
+###############################################################################
+# Label Node Locations
+# ++++++++++++++++++++
+
+# Load example beam file
+grid = vtki.UnstructuredGrid(examples.hexbeamfile)
+
+# Create plotting class and add the unstructured grid
+plotter = vtki.Plotter()
+plotter.add_mesh(grid, show_edges=True, color='tan')
+
+# Add labels to points on the yz plane (where x == 0)
+points = grid.points
+mask = points[:, 0] == 0
+plotter.add_point_labels(points[mask], points[mask].tolist())
+
+plotter.camera_position = [
+                (-1.4643015810492384, 1.5603923627830638, 3.16318236536270),
+                (0.05268120500967251, 0.639442034364944, 1.204095304165153),
+                (0.2364061044392675, 0.9369426029156169, -0.25739213784721)]
+
+plotter.show()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -435,3 +435,11 @@ def test_bad_instantiation():
         vtki.ipy_tools.InteractiveTool()
     with pytest.raises(TypeError):
         vtki.BasePlotter()
+
+
+def test_string_arrays():
+    poly = vtki.PolyData(np.random.rand(10, 3))
+    arr = np.array(['foo{}'.format(i) for i in range(10)])
+    poly['foo'] = arr
+    back = poly['foo']
+    assert len(back) == 10

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -12,7 +12,8 @@ from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 import vtki
 from vtki import DataSetFilters
 from vtki.utilities import (CELL_DATA_FIELD, POINT_DATA_FIELD, get_scalar,
-                            vtk_bit_array_to_char, is_vtki_obj, _raise_not_matching)
+                            vtk_bit_array_to_char, is_vtki_obj,
+                            _raise_not_matching, convert_array)
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
@@ -312,7 +313,7 @@ class Common(DataSetFilters, object):
             field, name = self.active_scalar_info
             if field != POINT_DATA_FIELD:
                 raise RuntimeError('Must specify an array to fetch.')
-        vtkarr = self.GetPointData().GetArray(name)
+        vtkarr = self.GetPointData().GetAbstractArray(name)
         if vtkarr is None:
             raise AssertionError('({}) is not a point scalar'.format(name))
 
@@ -322,7 +323,7 @@ class Common(DataSetFilters, object):
             if name not in self._point_bool_array_names:
                 self._point_bool_array_names.append(name)
 
-        array = vtk_to_numpy(vtkarr)
+        array = convert_array(vtkarr)
         if array.dtype == np.uint8 and name in self._point_bool_array_names:
             array = array.view(np.bool)
         return array
@@ -347,8 +348,11 @@ class Common(DataSetFilters, object):
             must be kept to avoid a segfault.
 
         """
+        if scalars is None:
+            raise TypeError('None is not an arry')
+
         if not isinstance(scalars, np.ndarray):
-            raise TypeError('Input must be a numpy.ndarray')
+            scalars = np.array(scalars)
 
         if scalars.shape[0] != self.n_points:
             raise Exception('Number of scalars must match the number of ' +
@@ -364,7 +368,7 @@ class Common(DataSetFilters, object):
         if not scalars.flags.c_contiguous:
             scalars = np.ascontiguousarray(scalars)
 
-        vtkarr = numpy_to_vtk(scalars, deep=deep)
+        vtkarr = convert_array(scalars, deep=deep)
         vtkarr.SetName(name)
         self.GetPointData().AddArray(vtkarr)
         if set_active or self.active_scalar_info[1] is None:
@@ -478,7 +482,7 @@ class Common(DataSetFilters, object):
             if field != CELL_DATA_FIELD:
                 raise RuntimeError('Must specify an array to fetch.')
 
-        vtkarr = self.GetCellData().GetArray(name)
+        vtkarr = self.GetCellData().GetAbstractArray(name)
         if vtkarr is None:
             raise AssertionError('({}) is not a cell scalar'.format(name))
 
@@ -488,7 +492,7 @@ class Common(DataSetFilters, object):
             if name not in self._cell_bool_array_names:
                 self._cell_bool_array_names.append(name)
 
-        array = vtk_to_numpy(vtkarr)
+        array = convert_array(vtkarr)
         if array.dtype == np.uint8 and name in self._cell_bool_array_names:
             array = array.view(np.bool)
         return array
@@ -513,8 +517,11 @@ class Common(DataSetFilters, object):
             must be kept to avoid a segfault.
 
         """
+        if scalars is None:
+            raise TypeError('None is not an arry')
+
         if not isinstance(scalars, np.ndarray):
-            raise TypeError('Input must be a numpy.ndarray')
+            scalars = np.array(scalars)
 
         if scalars.shape[0] != self.n_cells:
             raise Exception('Number of scalars must match the number of cells (%d)'
@@ -526,7 +533,7 @@ class Common(DataSetFilters, object):
             scalars = scalars.view(np.uint8)
             self._cell_bool_array_names.append(name)
 
-        vtkarr = numpy_to_vtk(scalars, deep=deep)
+        vtkarr = convert_array(scalars, deep=deep)
         vtkarr.SetName(name)
         self.GetCellData().AddArray(vtkarr)
         if set_active or self.active_scalar_info[1] is None:
@@ -702,7 +709,7 @@ class Common(DataSetFilters, object):
         if isinstance(arr, str):
             arr = get_scalar(self, arr, preference=preference)
         # If array has no tuples return a NaN range
-        if arr is None or arr.size == 0:
+        if arr is None or arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
             return (np.nan, np.nan)
         # Use the array range
         return np.nanmin(arr), np.nanmax(arr)
@@ -730,6 +737,10 @@ class Common(DataSetFilters, object):
         # First check points - think of case with vertex cells
         #   there would be the same number of cells as points but we'd want
         #   the data to be on the nodes.
+        if scalars is None:
+            raise TypeError('None is not an arry')
+        if not isinstance(scalars, np.ndarray):
+            scalars = np.array(scalars)
         if scalars.shape[0] == self.n_points:
             self.point_arrays[name] = scalars
         elif scalars.shape[0] == self.n_cells:

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -349,7 +349,7 @@ class Common(DataSetFilters, object):
 
         """
         if scalars is None:
-            raise TypeError('None is not an arry')
+            raise TypeError('Empty array unable to be added')
 
         if not isinstance(scalars, np.ndarray):
             scalars = np.array(scalars)
@@ -518,7 +518,7 @@ class Common(DataSetFilters, object):
 
         """
         if scalars is None:
-            raise TypeError('None is not an arry')
+            raise TypeError('Empty array unable to be added')
 
         if not isinstance(scalars, np.ndarray):
             scalars = np.array(scalars)
@@ -738,7 +738,7 @@ class Common(DataSetFilters, object):
         #   there would be the same number of cells as points but we'd want
         #   the data to be on the nodes.
         if scalars is None:
-            raise TypeError('None is not an arry')
+            raise TypeError('Empty array unable to be added')
         if not isinstance(scalars, np.ndarray):
             scalars = np.array(scalars)
         if scalars.shape[0] == self.n_points:

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -17,7 +17,7 @@ from vtk.util import numpy_support as VN
 import vtki
 from vtki.export import export_plotter_vtkjs
 from vtki.utilities import (get_scalar, is_vtki_obj, numpy_to_texture, wrap,
-                            _raise_not_matching)
+                            _raise_not_matching, convert_array)
 
 _ALL_PLOTTERS = {}
 
@@ -893,11 +893,12 @@ class BasePlotter(object):
             else:
                 # Make sure scalar components are not vectors/tuples
                 scalars = mesh.active_scalar
-                if scalars is None:# or scalars.ndim != 1:
-                    scalars = None
-                else:
+                # Don't allow plotting of string arrays by default
+                if scalars is not None and np.issubdtype(scalars.dtype, np.number):
                     if stitle is None:
                         stitle = mesh.active_scalar_info[1]
+                else:
+                    scalars = None
 
         if texture == True or isinstance(texture, (str, int)):
             texture = mesh._activate_texture(texture)
@@ -940,6 +941,9 @@ class BasePlotter(object):
 
             if not isinstance(scalars, np.ndarray):
                 scalars = np.asarray(scalars)
+
+            if not np.issubdtype(scalars.dtype, np.number):
+                raise TypeError('Non-numeric scalars are currently not supported for plotting.')
 
             if rgb is False or rgb is None:
                 rgb = kwargs.get('rgba', False)
@@ -1853,7 +1857,7 @@ class BasePlotter(object):
         vtk_scalars = data.GetScalars()
         if vtk_scalars is None:
             raise Exception('No active scalars')
-        s = VN.vtk_to_numpy(vtk_scalars)
+        s = convert_array(vtk_scalars)
         s[:] = scalars
         data.Modified()
         try:
@@ -2147,21 +2151,22 @@ class BasePlotter(object):
             self.remove_actor(self.scalar_bar, reset_camera=False)
 
     def add_point_labels(self, points, labels, italic=False, bold=True,
-                         font_size=None, text_color='k',
+                         font_size=None, text_color=None,
                          font_family=None, shadow=False,
-                         show_points=True, point_color='k', point_size=5,
-                         name=None):
+                         show_points=True, point_color=None, point_size=5,
+                         name=None, **kwargs):
         """
         Creates a point actor with one label from list labels assigned to
         each point.
 
         Parameters
         ----------
-        points : np.ndarray
-            n x 3 numpy array of points.
+        points : np.ndarray or vtki.Common
+            n x 3 numpy array of points or vtki dataset with points
 
-        labels : list
-            List of labels.  Must be the same length as points.
+        labels : list or str
+            List of labels.  Must be the same length as points. If a string name
+            is given with a vtki.Common input for points, then these are fetched.
 
         italic : bool, optional
             Italicises title and bar labels.  Default False.
@@ -2172,9 +2177,8 @@ class BasePlotter(object):
         font_size : float, optional
             Sets the size of the title font.  Defaults to 16.
 
-        text_color : string or 3 item list, optional, defaults to black
-            Color of text.
-            Either a string, rgb list, or hex color string.  For example:
+        text_color : string or 3 item list, optional
+            Color of text. Either a string, rgb list, or hex color string.
 
                 text_color='white'
                 text_color='w'
@@ -2190,8 +2194,7 @@ class BasePlotter(object):
         show_points : bool, optional
             Controls if points are visible.  Default True
 
-        point_color : string or 3 item list, optional, defaults to black
-            Color of points (if visible).
+        point_color : string or 3 item list, optional. Color of points (if visible).
             Either a string, rgb list, or hex color string.  For example:
 
                 text_color='white'
@@ -2217,11 +2220,25 @@ class BasePlotter(object):
             font_family = rcParams['font']['family']
         if font_size is None:
             font_size = rcParams['font']['size']
+        if point_color is None and text_color is None and kwargs.get('color', None) is not None:
+            point_color = kwargs.get('color', None)
+            text_color = kwargs.get('color', None)
+        if point_color is None:
+            point_color = rcParams['color']
+        if text_color is None:
+            text_color = rcParams['font']['color']
 
-        if len(points) != len(labels):
+        if isinstance(points, np.ndarray):
+            vtkpoints = vtki.PolyData(points) # Cast to poly data
+        elif is_vtki_obj(points):
+            vtkpoints = vtki.PolyData(points.points)
+            if isinstance(labels, str):
+                labels = points.point_arrays[labels].astype(str)
+        else:
+            raise TypeError('Points type not useable: {}'.format(type(points)))
+
+        if len(vtkpoints.points) != len(labels):
             raise Exception('There must be one label for each point')
-
-        vtkpoints = vtki.PolyData(points)
 
         vtklabels = vtk.vtkStringArray()
         vtklabels.SetName('labels')

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -2150,6 +2150,7 @@ class BasePlotter(object):
         if hasattr(self, 'scalar_bar'):
             self.remove_actor(self.scalar_bar, reset_camera=False)
 
+
     def add_point_labels(self, points, labels, italic=False, bold=True,
                          font_size=None, text_color=None,
                          font_family=None, shadow=False,
@@ -2272,6 +2273,36 @@ class BasePlotter(object):
 
         self.add_actor(labelActor, reset_camera=False, name=name)
         return labelMapper
+
+
+    def add_point_scalar_labels(self, points, labels, fmt=None, preamble='', **kwargs):
+        """Wrapper for :func:`vtki.BasePlotter.add_point_labels` that will label
+        points from a dataset with their scalar values.
+
+        Parameters
+        ----------
+        points : np.ndarray or vtki.Common
+            n x 3 numpy array of points or vtki dataset with points
+
+        labels : str
+            String name of the point data array to use.
+
+        fmt : str
+            String formatter used to format numerical data
+        """
+        if not is_vtki_obj(points):
+            raise TypeError('input points must be a vtki dataset, not: {}'.format(type(points)))
+        if not isinstance(labels, str):
+            raise TypeError('labels must be a string name of the scalar array to use')
+        if fmt is None:
+            fmt = rcParams['font']['fmt']
+        if fmt is None:
+            fmt = '%.6e'
+        scalars = points.point_arrays[labels]
+        phrase = '{} {}'.format(preamble, '%.3e')
+        labels = [phrase % val for val in scalars]
+        return self.add_point_labels(points, labels, **kwargs)
+
 
     def add_points(self, points, **kwargs):
         """ Add points to a mesh """


### PR DESCRIPTION
String data arrays are now supported for point and cell data!!

## Changes

- Conversion between `vtkStringArray` and a numpy array of `np.dtype('|S')` is now supported
- When adding a scalar array, the array is cast to numpy array if not already one. This allows users to pass lists and pandas series.
- A new `vtki.convert_array` function is implemented to handle nuances of converting between numpy and VTK arrays - *make sure to use this when converting data arrays*, spatial reference arrays like points, cells, etc do not need to use this converter.
- This also makes the point labeling function a bit better

Note that this is related to #64 

## Examples

Take a look at the examples added for this - here's one:

```py
import vtki
import numpy as np

# Make some random points
poly = vtki.PolyData(np.random.rand(10, 3))

# Add String array
poly['My Labels'] = ['Label {}'.format(i) for i in range(poly.n_points)]

# Plot and label
plotter = vtki.Plotter()
plotter.add_point_labels(poly, 'My Labels', point_size=20, font_size=36)
plotter.show()
```

![sphx_glr_plot-labels_001](https://user-images.githubusercontent.com/22067021/57042781-e77e1b00-6c22-11e9-8696-2b49d08cf0ce.png)


## Future Work

We might want to add a way to map unique strings to a categorized colormap. This is doable in ParaView and likely wouldn't be too difficult to implement in `vtki`. In the meantime, I added a change that will throw an error if a user tries to plot string data on a mesh.