### PR TITLE
Added cell extraction from point indices

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -384,3 +384,13 @@ def test_grid_points():
     grid.points = points
     assert grid.dimensions == [2, 2, 2]
     assert np.allclose(np.unique(grid.points, axis=0), np.unique(points, axis=0))
+
+
+def test_grid_extract_selection_points():
+    grid = vtki.UnstructuredGrid(sgrid)
+    sub_grid = grid.extract_selection_points([0])
+    assert sub_grid.n_cells == 1
+
+    sub_grid = grid.extract_selection_points(range(100))
+    assert sub_grid.n_cells > 1
+    

--- a/vtki/filters.py
+++ b/vtki/filters.py
@@ -945,7 +945,7 @@ class DataSetFilters(object):
         return _get_output(alg)
 
     def select_enclosed_points(dataset, surface, tolerance=0.001,
-                inside_out=False, check_surface=True):
+                               inside_out=False, check_surface=True):
         """Mark points as to whether they are inside a closed surface.
         This evaluates all the input points to determine whether they are in an
         enclosed surface. The filter produces a (0,1) mask

--- a/vtki/pointset.py
+++ b/vtki/pointset.py
@@ -1755,12 +1755,6 @@ class PointGrid(vtki.Common):
                                   non_manifold_edges, feature_edges,
                                   manifold_edges, inplace=inplace)
 
-    # def select_enclosed_points(self, points):
-    #     """Given an array or polydata, returns the points within this
-    #     polydata.
-
-    #     """
-
 
 class UnstructuredGrid(vtkUnstructuredGrid, PointGrid):
     """
@@ -2140,11 +2134,11 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid):
 
     def extract_selection_points(self, ind):
         """Returns a subset of the grid that contains the cells that
-        contain any of the point indices
+        contain any of the point indices.
 
         Parameters
         ----------
-        ind : np.ndarray
+        ind : np.ndarray, list, or iterable
             Numpy array of point indices to be extracted.
 
         Returns


### PR DESCRIPTION
Adds cell extraction from point indices

```python
import vtki
import vtk
import numpy as np

def voxelize(mesh, density):
    x_min, x_max, y_min, y_max, z_min, z_max = mesh.bounds
    x = np.arange(x_min, x_max, density)
    y = np.arange(y_min, y_max, density)
    z = np.arange(z_min, z_max, density)
    x, y, z = np.meshgrid(x, y, z)

    # Create unstructured grid from the structured grid
    grid = vtki.StructuredGrid(x, y, z)
    ugrid = vtki.UnstructuredGrid(grid)

    # get part of the mesh within the mesh
    selection = ugrid.select_enclosed_points(mesh, tolerance=0.0)
    mask = selection.point_arrays['SelectedPoints'].view(np.bool)

    # extract cells from point indices
    return ugrid.extract_selection_points(mask)


def text_3d(string, depth=0.5):
    """ Create 3D text """
    vec_text = vtk.vtkVectorText()
    vec_text.SetText(string)

    extrude = vtk.vtkLinearExtrusionFilter()
    extrude.SetInputConnection(vec_text.GetOutputPort())
    extrude.SetExtrusionTypeToNormalExtrusion();
    extrude.SetVector(0, 0, 1 )
    extrude.SetScaleFactor(depth)

    tri_filter = vtk.vtkTriangleFilter()
    tri_filter.SetInputConnection(extrude.GetOutputPort())
    tri_filter.Update()
    return vtki.wrap(tri_filter.GetOutput())
```

Demoing cell extraction from point indices:
```python
grid = voxelize(text_3d('vtki'), 0.05)
grid.plot(color='w', show_edges=True)
```
![Visualization Toolkit - OpenGL_054](https://user-images.githubusercontent.com/11981631/57129075-ac502900-6d95-11e9-9a6d-8954ed0048e5.png)

