### PR TITLE
Add field data arrays

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,7 +13,7 @@ py2 = sys.version_info.major == 2
 
 
 def test_point_arrays():
-    key = 'test_array'
+    key = 'test_array_points'
     grid[key] = np.arange(grid.n_points)
     assert key in grid.point_arrays
 
@@ -39,7 +39,7 @@ def test_point_arrays_bad_value():
 
 
 def test_cell_arrays():
-    key = 'test_array'
+    key = 'test_array_cells'
     grid[key] = np.arange(grid.n_cells)
     assert key in grid.cell_arrays
 
@@ -62,6 +62,27 @@ def test_cell_arrays_bad_value():
 
     with pytest.raises(Exception):
         grid.cell_arrays['new_array'] = np.arange(grid.n_cells - 1)
+
+
+def test_cell_arrays():
+    key = 'test_array_field'
+    # Add array of lenght not equal to n_cells or n_points
+    n = grid.n_cells // 3
+    grid.field_arrays[key] = np.arange(n)
+    assert key in grid.field_arrays
+    assert np.allclose(grid.field_arrays[key], np.arange(n))
+
+    orig_value = grid.field_arrays[key][0]/1.0
+    grid.field_arrays[key][0] += 1
+    assert orig_value == grid.field_arrays[key][0] -1
+
+    del grid.field_arrays[key]
+    assert key not in grid.field_arrays
+
+
+def test_cell_arrays_bad_value():
+    with pytest.raises(TypeError):
+        grid.field_arrays['new_array'] = None
 
 
 def test_copy():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -64,15 +64,18 @@ def test_get_scalar():
     grid._add_cell_scalar(carr, 'test_data')
     parr = np.random.rand(grid.n_points)
     grid._add_point_scalar(parr, 'test_data')
+    # add other data
     oarr = np.random.rand(grid.n_points)
     grid._add_point_scalar(oarr, 'other')
+    farr = np.random.rand(grid.n_points * grid.n_cells)
+    grid._add_field_scalar(farr, 'field_data')
     assert np.allclose(carr, utilities.get_scalar(grid, 'test_data', preference='cell'))
     assert np.allclose(parr, utilities.get_scalar(grid, 'test_data', preference='point'))
     assert np.allclose(oarr, utilities.get_scalar(grid, 'other'))
     assert None == utilities.get_scalar(grid, 'foo')
-    # check errors
-    with pytest.raises(RuntimeError):
-        foo = utilities.get_scalar(grid, 'test_data', preference='field')
+    assert utilities.get_scalar(grid, 'test_data', preference='field') is None
+    assert np.allclose(farr, utilities.get_scalar(grid, 'field_data', preference='field'))
+
 
 
 

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -852,11 +852,14 @@ class Common(DataSetFilters, object):
             raise TypeError('Empty array unable to be added')
         if not isinstance(scalars, np.ndarray):
             scalars = np.array(scalars)
-        elif scalars.shape[0] == self.n_points:
+        # Now check array size to determine which field to place array
+        if scalars.shape[0] == self.n_points:
             self.point_arrays[name] = scalars
         elif scalars.shape[0] == self.n_cells:
             self.cell_arrays[name] = scalars
         else:
+            # Field data must be set explicitly as it could be a point of
+            # confusion for new users
             _raise_not_matching(scalars, self)
         return
 

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -959,17 +959,24 @@ class Common(DataSetFilters, object):
             fmt += "</td><td>"
             fmt += "\n"
             fmt += "<table>\n"
-            row = "<tr><th>{}</th><th>{}</th><th>{}</th><th>{}</th><th>{}</th></tr>\n"
-            fmt += row.format("Name", "Field", "Type", "Min", "Max")
-            row = "<tr><td>{}</td><td>{}</td><td>{}</td><td>{:.3e}</td><td>{:.3e}</td></tr>\n"
+            titles = ["Name", "Field", "Type", "N Comp", "Min", "Max"]
+            fmt += "<tr>" + "".join(["<th>{}</th>".format(t) for t in titles]) + "</tr>\n"
+            row = "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>\n"
+            row = "<tr>" + "".join(["<td>{}</td>" for i in range(len(titles))]) + "</tr>\n"
 
             def format_array(key, field):
                 """internal helper to foramt array information for printing"""
-                arr = get_scalar(self, key)
+                arr = get_scalar(self, key, preference=field)
                 dl, dh = self.get_data_range(key)
+                dl = '{:.3e}'.format(dl)
+                dh = '{:.3e}'.format(dh)
                 if key == self.active_scalar_info[1]:
                     key = '<b>{}</b>'.format(key)
-                return row.format(key, field, arr.dtype, dl, dh)
+                if arr.ndim > 1:
+                    ncomp = arr.shape[1]
+                else:
+                    ncomp = 1
+                return row.format(key, field, arr.dtype, ncomp, dl, dh)
 
             for i in range(self.GetPointData().GetNumberOfArrays()):
                 key = self.GetPointData().GetArrayName(i)

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -659,9 +659,6 @@ class Common(DataSetFilters, object):
         """ removes point scalars from point data """
         self.GetPointData().RemoveArray(key)
 
-    def _remove_field_scalar(self, key):
-        """ removes field scalars from field data """
-        self.GetFieldData().RemoveArray(key)
 
     @property
     def point_arrays(self):
@@ -688,6 +685,12 @@ class Common(DataSetFilters, object):
 
         self._point_arrays.enable_callback()
         return self._point_arrays
+
+
+    def _remove_field_scalar(self, key):
+        """ removes field scalars from field data """
+        self.GetFieldData().RemoveArray(key)
+
 
     @property
     def field_arrays(self):

--- a/vtki/utilities.py
+++ b/vtki/utilities.py
@@ -172,7 +172,7 @@ def get_scalar(mesh, name, preference='cell', info=False, err=False):
             preference = FIELD_DATA_FIELD
         else:
             raise RuntimeError('Data field ({}) not supported.'.format(preference))
-    if all([parr is not None, carr is not None, farr is not None]):
+    if np.sum([parr is not None, carr is not None, farr is not None]) > 1:
         if preference == CELL_DATA_FIELD:
             if info:
                 return carr, CELL_DATA_FIELD
@@ -194,13 +194,13 @@ def get_scalar(mesh, name, preference='cell', info=False, err=False):
     field = None
     if parr is not None:
         arr = parr
-        field = 0
+        field = POINT_DATA_FIELD
     elif carr is not None:
         arr = carr
-        field = 1
+        field = CELL_DATA_FIELD
     elif farr is not None:
         arr = farr
-        field = 2
+        field = FIELD_DATA_FIELD
     elif err:
         raise KeyError('Data scalar ({}) not present in this dataset.'.format(name))
     if info:

--- a/vtki/utilities.py
+++ b/vtki/utilities.py
@@ -409,10 +409,8 @@ def fit_plane_to_points(points, return_meta=False):
 
 
 def _raise_not_matching(scalars, mesh):
-    raise Exception('Number of scalars (%d) ' % scalars.size +
+    raise Exception('Number of scalars ({})'.format(scalars.size) +
                     'must match either the number of points ' +
-                    '(%d) ' % mesh.n_points +
+                    '({}) '.format(mesh.n_points) +
                     'or the number of cells ' +
-                    '(%d). ' % mesh.n_cells +
-                    'For setting field data, please use ' +
-                    'vtki.Common.add_field_array.')
+                    '({}). '.format(mesh.n_cells) )

--- a/vtki/utilities.py
+++ b/vtki/utilities.py
@@ -164,6 +164,7 @@ def get_scalar(mesh, name, preference='cell', info=False, err=False):
     carr = cell_scalar(mesh, name)
     farr = field_scalar(mesh, name)
     if isinstance(preference, str):
+        preference = preference.strip().lower()
         if preference in ['cell', 'c', 'cells']:
             preference = CELL_DATA_FIELD
         elif preference in ['point', 'p', 'points']:


### PR DESCRIPTION
### Description

VTK objects are affiliated with three types of data: point data, cell data, and field data. Only the former two are currently implemented in vtki, which makes it such that there is no straightforward way of embedding arrays and similar that one might want affiliated with the object in question. See https://vtk.org/Wiki/VTK/Tutorials/DataStorage for more info.

(originally posted in #206)

### This PR

* adds functionality from VTK that is not currently accessible in vtki
* enables storing of arrays of arbitrary length in VTK objects

### Note

* I believe the safety check of ensuring that the input array is of length mesh.n_points of mesh.n_cells when setting array data is good to have, as field data should be reserved for very particular kinds of additional data. The way in which I've implemented adding a field_array is therefore through the use of vtki.Common.add_field_array. Other functionality is mimicked after how cell/point data is handled.
* #187 and #203 mention the need for storing non-traditional kinds of data in vtki objects. This feature still requires arrays of dimensionality > 0 to have individual elements of the same type (and if applicable, length).
* field arrays can never be set as the active scalar array
